### PR TITLE
fix: edits to activity 3 and supporting lesson

### DIFF
--- a/clean-modular-code/activity-3/clean-code-activity-3.md
+++ b/clean-modular-code/activity-3/clean-code-activity-3.md
@@ -20,6 +20,8 @@ kernelspec:
 
 In this activity, you will build checks into your workflow to handle data processing "features". 
 
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
 ### Real world data processing & workflows and edge cases 
 
 Real-world data rarely can be imported without "work arounds". You will often find unusual data entries and values you don't expect. Sometimes, these values are documented - for example, a 9999 may represent a missing value in a dataset. Other times, there are typos and other errors in the data that you need to handle. These unusual values or instances in a dataset or workflow are sometimes called "edge cases".  
@@ -32,32 +34,23 @@ Using functions, classes, and methods (functions within a class) is a great firs
 Once you have these functions and methods, you can add checks using conditional statements and try/except blocks that anticipate edge cases and errors that you may encounter when processing your data. 
 :::
 
-<!-- From JEREMY: Two suggestions I have for this lesson:
-encourage attendees to "fail fast"
-only when it is unrecoverable
-this makes the failure happen earlier, wasting less time waiting
-this can make the stack trace more useful, as it points the the code experiencing the error
-
-clearly describe the error.
-rather than just printing out "exiting now", try to tell the caller why it was a mistake, and what they could maybe do to fix it.
-maybe also explain that exceptions can (most of the time) take a message string, and it doesn't have to be printed also. -->
-
 ## Manage the unexpected 
 
-In this activity, you will apply the following strategies to make your code more robust,  maintainable & usable:
+In this activity, you will apply the following strategies to make your code more robust, maintainable & usable:
 
-* Fail fast strategy: more here
-* Use [conditional statements](../checks-conditionals/python-conditionals) and/or try/except blocks to catch errors and return useful output
+* **[Fail fast with useful error messages](fail-fast)**: Failing fast is a software engineering term that means allowing your 
+  code to stop early when something goes wrong, ensuring that errors are caught 
+  and communicated clearly. This helps the user quickly understand what went 
+  wrong and where.
+* Use **[conditional statements](../checks-conditionals/python-conditionals)** 
+  to check for specific conditions before executing certain parts of your code, 
+  which can help catch issues early.
+* **[Try/except blocks](../checks-conditionals/python-function-checks)** allow 
+  you to handle potential errors by attempting an operation and catching any 
+  exceptions if they occur, providing useful feedback without crashing the 
+  entire program.
 
-to process the JOSS citation data. 
-
-:::{todo}
-What branch is the lesson with try/except // ask for forgiveness, checks elements in??
-IN THIS PR:
-https://github.com/pyOpenSci/lessons/pull/14/files#diff-7f4ff1b75e85d38f3955cca051e68e8746773c279b34c9a0a400b9c2dc1240ff 
-:::
-
-When you can, try to use the Pythonic approach of asking for forgiveness later (ie use try/except blocks) rather than conditional statements.
+When you can, try to use a [Pythonic approach](pythonic-checks) to catch errors early. This means asking for forgiveness later (often using try/except blocks) vs using conditional statements to check the state or type of an object.
 
 ```{code-cell} ipython3
 ---
@@ -65,7 +58,7 @@ editable: true
 slideshow:
   slide_type: ''
 ---
-# This works but is less pythonic
+# This works but is less Pythonic as it's a look before you leap approach
 def clean_title(title):
     """Notice that this function checks explicitly to see if it's a list and then processes the data.
     """
@@ -87,13 +80,17 @@ slideshow:
 # This is the preferred way to catch an error 
 def clean_title(title):
     """
-    It's more Pythonic to try first and then ask for forgiveness later. 
-    If you are writing tests this also makes your code easier to test. 
+    Attempts to return the first character of the title.
+    Raises the same error with a friendly message if the input is invalid.
     """
     try:
         return title[0]
-    except (TypeError, IndexError):
-        return title
+    except IndexError as e:
+        raise IndexError(f"Oops! You provided a title in an unexpected format. I expected the title to be provided in a list and you provided a {type(title)}.") from e
+
+# Example usage:
+title = ""
+print(clean_title(title))  # This will raise an IndexError with the friendly message
 ```
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}, "tags": ["hide-output", "hide-cell"]}
@@ -112,24 +109,40 @@ You can use `.apply` in pandas to efficiently replace `for loops` to process row
 ### What's changed in your workflow?
 
 :::{warning}
-You have a new data file to open in your list of `.json` files in this activity. This file has some unexpected "features" that your code needs to handle gracefully so it can process all of the data.
+You have a new data file to open in your list of `.json` files in this activity. This file has some unexpected "features" that your code needs to handle gracefully to process all of the data.
 :::
 
-Your goal is to make the code below run on the data provided in the activity-3 `data/` directory.  
+The code below is an example of what your code might look like after completing activity 2. You can choose to work with this code, or you can use the code that you completed in activity 2. 
+Your goal is to make the code below run on the data provided in the activity-3 `data/` directory.
+
+The code below will fail. You will need to do the following:
+
+1. Use a debugger to determine why it's failing.
+2. Add try/except blocks and/or conditional statements to your functions that handle various exceptions.
+
+Your end goal is to make the code below run. 
 
 :::{tip}
-The code below will fail. You will likely want to use a debugger to determine why it's failing and get the code running. 
-
 * If you are using Jupyter, then you might [find this page helpful when setting up debugging.](https://jupyterlab.readthedocs.io/en/stable/user/debugger.html)
 * VSCODE has a nice visual debugger that you can use.
 
 :::
 
-The code below is an example of what your code might look like after completing activity 2. You can choose to work with this code, or you can use the code that you completed in activity 2.
+
+Important: It is ok if you can't get the code to run fully by the end of this workshop. If you can:
+
+1. identify at least one of the data processing "bugs" (even if you can't fix it) and/or
+2. fix at least one bug
+
+You can consider your effort today as a success!
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}, "tags": ["raises-exception"]}
 
+## TODO: double check this is the right code from activity 2 - there are clear errors that i just fixed. but it needs to actually run
+
 ```python
+# Note that this code has no checks or tests in the functions provided. You will need to add them to make the code run. 
+
 import json
 from pathlib import Path
 
@@ -172,36 +185,16 @@ def format_date(date_parts: list) -> str:
 
     Returns
     -------
-    str
-        Formatted date string.
+    pd.datetime
+        A date formatted as a pd.datetime object.
     """
-    return f"{date_parts[0]}-{date_parts[1]:02d}-{date_parts[2]:02d}"
+    date_str = f("{date_parts[0]}-{date_parts[1]:02d}-{date_parts[2]:02d}")
+    return pd.to_datetime(date_str, format="%Y-%m-%d")
 
 
 def clean_title(value):
     """A function that removes a value contained in a list."""
     return value[0]
-
-
-def process_published_date(date_parts):
-    """Parse a date provided as a list of values into a proper date format.
-
-    Parameters
-    ----------
-    date_parts : str or int
-        The elements of a date provided as a list from CrossRef
-
-    Returns
-    -------
-    pd.datetime
-        A date formatted as a pd.datetime object.
-    """
-
-    date_str = (
-        f"{date_parts[0][0]}-{date_parts[0][1]:02d}-{date_parts[0][2]:02d}"
-    )
-    return pd.to_datetime(date_str, format="%Y-%m-%d")
-
 
 columns_to_keep = [
     "publisher",

--- a/clean-modular-code/activity-3/clean-code-activity-3.md
+++ b/clean-modular-code/activity-3/clean-code-activity-3.md
@@ -42,11 +42,11 @@ Once you have these functions and methods, you can add checks using conditional 
 In this activity, you will apply the following strategies to make your code more robust, maintainable & usable:
 
 * **[Fail fast with useful error messages](fail-fast)**: Failing fast is a software engineering term that means allowing your 
-  code to stop early when something goes wrong, ensuring that errors are caught 
-  and communicated clearly. This helps the user quickly understand what went 
-  wrong and where.
+  code to stop when something goes wrong, ensuring that errors are caught 
+  and communicated promptly. This helps the user quickly understand the error, what went 
+  wrong, and where.
 * Use **[conditional statements](../checks-conditionals/python-conditionals)** 
-  to check for specific conditions before executing certain parts. This allows you to create specific workflows that your code followed based on specific conditions.
+  to logically check for specific conditions before executing code. This allows you to create different pathways for code to execute based on specific conditions.
 * **[Try/except blocks](../checks-conditionals/python-function-checks)** allow 
   you to handle potential errors by attempting an operation and catching any 
   exceptions if they occur, providing useful feedback. In some cases you may want the program to end on an error. In other cases, you may want to handle it in a specific way. 
@@ -59,7 +59,7 @@ editable: true
 slideshow:
   slide_type: ''
 ---
-# This works but is less Pythonic as it's a look before you leap approach
+# This works but is less Pythonic as it's a "look before you leap" approach since it does an extra check before returning the title
 def clean_title(title):
     """Notice that this function checks explicitly to see if it's a list and then processes the data.
     """
@@ -81,7 +81,7 @@ tags: [raises-exception]
 def clean_title(title):
     """
     Attempts to return the first character of the title.
-    Raises the same error with a friendly message if the input is invalid.
+    Raises the same error with a friendly, custom error message if the input is invalid.
     """
     try:
         return title[0]
@@ -100,6 +100,7 @@ print(clean_title(title))  # This will raise an IndexError with the friendly mes
 def clean_title(title):
     """
     Attempts to return the first character of the title.
+
     Raises the same error with a friendly message if the input is invalid.
     """
     try:
@@ -114,7 +115,7 @@ print(clean_title(title))  # This will raise an IndexError with the friendly mes
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
-If you wish, you can shorten the amount of information returned in the exception by adding `from None` to your exception. This will look nicer to a user but you lose some information in the exception feedback. 
+If you wish, you can shorten the amount of information returned in the error by adding `from None` when you raise the error. This will look nicer to a user, but you lose some detail in the error traceback. 
 
 ```{code-cell} ipython3
 # This is the preferred way to catch an error 
@@ -137,7 +138,7 @@ print(clean_title(title))  # This will raise an IndexError with the friendly mes
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}, "tags": ["hide-output", "hide-cell"]}
 
-In this activity, you will be working with Pandas dataframes. You may find the .apply function to be particularly useful. 
+In this activity, you will be working with Pandas dataframes. You may find the `.apply` function to be particularly useful. 
 
 :::{tip}
 ### Applying functions to DataFrame values: `.apply` 

--- a/clean-modular-code/activity-3/clean-code-activity-3.md
+++ b/clean-modular-code/activity-3/clean-code-activity-3.md
@@ -15,7 +15,7 @@ kernelspec:
 
 # Activity 3: Tests & Checks for your code
 
-* In [activity 1](../activity-1/clean-code-activity-1), you took some code and made it cleaner using expressive variable names and docstrings to document the module. 
+* In [activity 1](../activity-1/clean-code-activity-1), you made your code cleaner and more usable using expressive variable names and docstrings to document the module. 
 * In [activity 2](../activity-2/clean-code-activity-2), you made your code more DRY ("Don't Repeat Yourself") using documented functions and conditionals. 
 
 In this activity, you will build checks into your workflow to handle data processing "features". 
@@ -26,8 +26,10 @@ In this activity, you will build checks into your workflow to handle data proces
 
 Real-world data rarely can be imported without "work arounds". You will often find unusual data entries and values you don't expect. Sometimes, these values are documented - for example, a 9999 may represent a missing value in a dataset. Other times, there are typos and other errors in the data that you need to handle. These unusual values or instances in a dataset or workflow are sometimes called "edge cases".  
 
-Writing robust code that handles unexpected values will make your code run smoothly and fail gracefully. This type of code, which combines functions (or classes) and checks within the functions that handle messy data, will make your code easier to maintain over time. 
+Writing robust code that handles unexpected values will make your code run smoothly and fail gracefully. This type of code, which combines functions (or classes) and checks within the functions that handle messy data, will make your code easier to maintain.
 
+Things like helpful error messages and fast failing will also improve the experience for someone else using your code - OR your future self. 
+ 
 :::{tip}
 Using functions, classes, and methods (functions within a class) is a great first step in handling messy data. A function or method provides a modular unit you can test outside of the workflow for the edge cases you may encounter. Also, because a function is a modular unit, you can add elements to handle unexpected processing features as you build your workflow.
 
@@ -43,14 +45,12 @@ In this activity, you will apply the following strategies to make your code more
   and communicated clearly. This helps the user quickly understand what went 
   wrong and where.
 * Use **[conditional statements](../checks-conditionals/python-conditionals)** 
-  to check for specific conditions before executing certain parts of your code, 
-  which can help catch issues early.
+  to check for specific conditions before executing certain parts. This allows you to create specific workflows that your code followed based on specific conditions.
 * **[Try/except blocks](../checks-conditionals/python-function-checks)** allow 
   you to handle potential errors by attempting an operation and catching any 
-  exceptions if they occur, providing useful feedback without crashing the 
-  entire program.
+  exceptions if they occur, providing useful feedback. In some cases you may want the program to end on an error. In other cases, you may want to handle it in a specific way. 
 
-When you can, try to use a [Pythonic approach](pythonic-checks) to catch errors early. This means asking for forgiveness later (often using try/except blocks) vs using conditional statements to check the state or type of an object.
+When you can, try to use a [Pythonic approach](pythonic-checks) to catch errors early; this means asking for forgiveness later (often using try/except blocks) vs. using conditional statements to check an object's state or type.
 
 ```{code-cell} ipython3
 ---
@@ -67,9 +67,9 @@ def clean_title(title):
     return title
 ```
 
-## More "pythonic" - ask for forgiveness 
++++ {"editable": true, "slideshow": {"slide_type": ""}}
 
-easier to ask for forgiveness
+
 
 ```{code-cell} ipython3
 ---
@@ -95,10 +95,14 @@ print(clean_title(title))  # This will raise an IndexError with the friendly mes
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}, "tags": ["hide-output", "hide-cell"]}
 
+In this activity, you will be working with Pandas dataframes. You may find the .apply function to be particularly useful. 
+
 :::{tip}
 ### Applying functions to DataFrame values--`.apply` 
 
-The `.apply()` function in pandas allows you to apply any function to rows or columns in a `pandas.DataFrame`. For example, You can use it to perform operations on specific column or row values. When you use `.apply()`, you can specify whether you want to apply the function across columns `(axis=0)` (the default) or across rows `(axis=1)`. For example, if you want to apply a function to each row of a DataFrame, you would use `df.apply(your_function, axis=1)`. This function is especially useful for applying logic that can’t be easily achieved with built-in pandas functions, allowing for more flexibility in data processing.
+The `.apply()` function in pandas allows you to apply any function to rows or columns in a `pandas.DataFrame`. For example, you can use it to perform operations on specific column or row values. When you use `.apply()`, you can specify whether you want to apply the function across columns `(axis=0)` (the default) or across rows `(axis=1)`. 
+
+For example, if you want to apply a function to each row of a DataFrame, you would use `df.apply(your_function, axis=1)`. This function is especially useful for applying logic that can’t be easily achieved with built-in pandas functions, allowing for more flexibility in data processing.
 
 You can use `.apply` in pandas to efficiently replace `for loops` to process row and column values in a `pandas.DataFrame`.
 
@@ -112,7 +116,8 @@ You can use `.apply` in pandas to efficiently replace `for loops` to process row
 You have a new data file to open in your list of `.json` files in this activity. This file has some unexpected "features" that your code needs to handle gracefully to process all of the data.
 :::
 
-The code below is an example of what your code might look like after completing activity 2. You can choose to work with this code, or you can use the code that you completed in activity 2. 
+The code below is an example of what your code might look like after completing [activity 2](../activity-2/clean-code-activity-2). You can choose to work with this code, or you can use the code that you completed in activity 2. 
+
 Your goal is to make the code below run on the data provided in the activity-3 `data/` directory.
 
 The code below will fail. You will need to do the following:
@@ -128,7 +133,6 @@ Your end goal is to make the code below run.
 
 :::
 
-
 Important: It is ok if you can't get the code to run fully by the end of this workshop. If you can:
 
 1. identify at least one of the data processing "bugs" (even if you can't fix it) and/or
@@ -137,8 +141,6 @@ Important: It is ok if you can't get the code to run fully by the end of this wo
 You can consider your effort today as a success!
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}, "tags": ["raises-exception"]}
-
-## TODO: double check this is the right code from activity 2 - there are clear errors that i just fixed. but it needs to actually run
 
 ```python
 # Note that this code has no checks or tests in the functions provided. You will need to add them to make the code run. 
@@ -188,13 +190,16 @@ def format_date(date_parts: list) -> str:
     pd.datetime
         A date formatted as a pd.datetime object.
     """
-    date_str = f("{date_parts[0]}-{date_parts[1]:02d}-{date_parts[2]:02d}")
+    date_str = (
+        f"{date_parts[0][0]}-{date_parts[0][1]:02d}-{date_parts[0][2]:02d}"
+    )
     return pd.to_datetime(date_str, format="%Y-%m-%d")
 
 
 def clean_title(value):
     """A function that removes a value contained in a list."""
     return value[0]
+
 
 columns_to_keep = [
     "publisher",
@@ -214,7 +219,7 @@ for json_file in data_dir.glob("*.json"):
 
     papers_df["title"] = papers_df["title"].apply(clean_title)
     papers_df["published_date"] = papers_df["published.date-parts"].apply(
-        process_published_date
+        format_date
     )
 
     all_papers_list.append(papers_df)
@@ -226,17 +231,98 @@ print("Final shape of combined DataFrame:", all_papers_df.shape)
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
-:::{admonition} On your own 1
-:class: attention
+## What i don't like
 
-Ideas for on your own welcome!
-:::
+What I don't like about this is that the file not found error isn't too bad to figure out. things like keyerrors and value errors are more amorphous. so this could be an OYO 2 
+
+and we could work through a index error or a key error instead?  Becuase in that case they may want to return a default value or something else.... 
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
-:::{admonition} On your own 2
+:::{admonition} Part 1 - What happens when your code can't find the data?
 :class: attention
-Ideas welcome?
+
+Let's break the code below and see how our code performs. 
+
+* Note that the code below has a modified `/data` directory path (that doesn't exist!).
+
+Questions:
+* What type of error do you expect Python to throw? Use Google, LLMs or our [tests and checks](common-exceptions) lesson to help figure this out. 
+* Does your code handle this error gracefully?
+* How can we make the code handle it better?
+
+```python
+import json
+from pathlib import Path
+
+import pandas as pd
+
+def load_clean_json(file_path, columns_to_keep):
+    """
+    Load JSON data from a file. Drop unnecessary columns and normalize
+    to DataFrame.
+
+    Parameters
+    ----------
+    file_path : Path
+        Path to the JSON file.
+    columns_to_keep : list
+        List of columns to keep in the DataFrame.
+
+    Returns
+    -------
+    dict
+        Loaded JSON data.
+    """
+
+    with file_path.open("r") as json_file:
+        json_data = json.load(json_file)
+    normalized_data = pd.json_normalize(json_data)
+
+    # Return the pandas DataFrame, filtering out some of the columns that we don't need
+    return normalized_data.filter(items=columns_to_keep)
+
+
+columns_to_keep = [
+    "publisher",
+    "DOI",
+    "type",
+    "author",
+    "is-referenced-by-count",
+    "title",
+    "published.date-parts",
+]
+
+# Break this data path by giving it a dir name that doesn't exist - what happens when your code runs?
+data_dir = Path("bad-bad-data")
+
+all_papers_list = []
+for json_file in data_dir.glob("*.json"):
+    papers_df = load_clean_json(json_file, columns_to_keep)
+    papers_df["title"] = papers_df["title"].apply(clean_title)
+
+    all_papers_list.append(papers_df)
+
+all_papers_df = pd.concat(all_papers_list, axis=0, ignore_index=True)
+
+print("Final shape of combined DataFrame:", all_papers_df.shape)
+```
+
+Your goal is to troubleshoot any issues associated with cleaning up the title so you can work with it later in a `pandas.DataFrame`.
+
+:::
+
++++ {"editable": true, "slideshow": {"slide_type": ""}, "tags": ["hide-cell"]}
+
+Note: we can have two groups - one that wants to work on their own and another that wants to work with the instructor together. 
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+:::{admonition} On your own 1
+:class: attention
+
+What happens 
+
 :::
 
 I want to have them move their code into a module if possible during this workshop but we could also kick that off in the day 2 workshop.

--- a/clean-modular-code/activity-3/clean-code-activity-3.md
+++ b/clean-modular-code/activity-3/clean-code-activity-3.md
@@ -18,7 +18,7 @@ kernelspec:
 * In [activity 1](../activity-1/clean-code-activity-1), you made your code cleaner and more usable using expressive variable names and docstrings to document the module. 
 * In [activity 2](../activity-2/clean-code-activity-2), you made your code more DRY ("Don't Repeat Yourself") using documented functions and conditionals. 
 
-In this activity, you will build checks into your workflow to handle data processing "features". 
+In this activity, you will build checks into your workflow to handle data processing "features".
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
@@ -67,9 +67,7 @@ def clean_title(title):
     return title
 ```
 
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-
+The function below raises an error with a custom error message. but you can still see the 
 
 ```{code-cell} ipython3
 ---
@@ -86,7 +84,47 @@ def clean_title(title):
     try:
         return title[0]
     except IndexError as e:
-        raise IndexError(f"Oops! You provided a title in an unexpected format. I expected the title to be provided in a list and you provided a {type(title)}.") from e
+        raise IndexError(f"Oops! You provided a title in an unexpected format. "
+                         f"I expected the title to be provided in a list and you provided "
+                         f"a {type(title)}.") from e
+
+# Example usage:
+title = ""
+print(clean_title(title))  # This will raise an IndexError with the friendly message
+```
+
+```{code-cell} ipython3
+# This is the preferred way to catch an error 
+def clean_title(title):
+    """
+    Attempts to return the first character of the title.
+    Raises the same error with a friendly message if the input is invalid.
+    """
+    try:
+        return title[0]
+    except IndexError as e:
+        raise IndexError(f"Oops! You provided a title in an unexpected format. I expected the title to be provided in a list and you provided a {type(title)}.") 
+
+# Example usage:
+title = ""
+print(clean_title(title))  # This will raise an IndexError with the friendly message
+```
+
+If you wish, you can shorten the amount of information returned in the exception by adding `from None` to your exception. This will look nicer to a user but you lose some information in the exception feedback. 
+
+```{code-cell} ipython3
+# This is the preferred way to catch an error 
+def clean_title(title):
+    """
+    Attempts to return the first character of the title.
+    Raises the same error with a friendly message if the input is invalid.
+    """
+    try:
+        return title[0]
+    except IndexError as e:
+        raise IndexError(f"Oops! You provided a title in an unexpected format. "
+                         f"I expected the title to be provided in a list and you provided "
+                         f"a {type(title)}.") from None 
 
 # Example usage:
 title = ""
@@ -138,7 +176,93 @@ Important: It is ok if you can't get the code to run fully by the end of this wo
 1. identify at least one of the data processing "bugs" (even if you can't fix it) and/or
 2. fix at least one bug
 
-You can consider your effort today as a success!
+You can consider your effort today as a success! We will work on the first element together as a group. 
+
+```{code-cell} ipython3
+import json
+from pathlib import Path
+
+import pandas as pd
+
+
+def load_clean_json(file_path, columns_to_keep):
+    """
+    Load JSON data from a file. Drop unnecessary columns and normalize
+    to DataFrame.
+
+    Parameters
+    ----------
+    file_path : Path
+        Path to the JSON file.
+    columns_to_keep : list
+        List of columns to keep in the DataFrame.
+
+    Returns
+    -------
+    dict
+        Loaded JSON data.
+    """
+
+    with file_path.open("r") as json_file:
+        json_data = json.load(json_file)
+    normalized_data = pd.json_normalize(json_data)
+
+    return normalized_data.filter(items=columns_to_keep)
+
+
+def format_date(date_parts: list) -> str:
+    """
+    Format date parts into a string.
+
+    Parameters
+    ----------
+    date_parts : list
+        List containing year, month, and day.
+
+    Returns
+    -------
+    pd.datetime
+        A date formatted as a pd.datetime object.
+    """
+    date_str = (
+        f"{date_parts[0][0]}-{date_parts[0][1]:02d}-{date_parts[0][2]:02d}"
+    )
+    return pd.to_datetime(date_str, format="%Y-%m-%d")
+
+
+def clean_title(value):
+    """A function that removes a value contained in a list."""
+    print("hi", value)
+    return value[0]
+
+
+columns_to_keep = [
+    "publisher",
+    "DOI",
+    "type",
+    "author",
+    "is-referenced-by-count",
+    "title",
+    "published.date-parts",
+]
+
+data_dir = Path("data")
+
+all_papers_list = []
+for json_file in data_dir.glob("*.json"):
+    papers_df = load_clean_json(json_file, columns_to_keep)
+
+    papers_df["title"] = papers_df["title"].apply(clean_title)
+    papers_df["published_date"] = papers_df["published.date-parts"].apply(
+        format_date
+    )
+
+    all_papers_list.append(papers_df)
+
+all_papers_df = pd.concat(all_papers_list, axis=0, ignore_index=True)
+
+print("Final shape of combined DataFrame:", all_papers_df.shape)
+```
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}, "tags": ["raises-exception"]}
 
@@ -235,7 +359,7 @@ print("Final shape of combined DataFrame:", all_papers_df.shape)
 
 What I don't like about this is that the file not found error isn't too bad to figure out. things like keyerrors and value errors are more amorphous. so this could be an OYO 2 
 
-and we could work through a index error or a key error instead?  Becuase in that case they may want to return a default value or something else.... 
+and we could work through a index error or a key error instead?  Becuase in that case they may want to return a default value or something else....
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
@@ -314,7 +438,7 @@ Your goal is to troubleshoot any issues associated with cleaning up the title so
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}, "tags": ["hide-cell"]}
 
-Note: we can have two groups - one that wants to work on their own and another that wants to work with the instructor together. 
+Note: we can have two groups - one that wants to work on their own and another that wants to work with the instructor together.
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 

--- a/clean-modular-code/activity-3/clean-code-activity-3.md
+++ b/clean-modular-code/activity-3/clean-code-activity-3.md
@@ -20,25 +20,34 @@ kernelspec:
 
 In this activity, you will build checks into your workflow to handle data processing "features". 
 
-
 ### Real world data processing & workflows and edge cases 
+
 Real-world data rarely can be imported without "work arounds". You will often find unusual data entries and values you don't expect. Sometimes, these values are documented - for example, a 9999 may represent a missing value in a dataset. Other times, there are typos and other errors in the data that you need to handle. These unusual values or instances in a dataset or workflow are sometimes called "edge cases".  
 
 Writing robust code that handles unexpected values will make your code run smoothly and fail gracefully. This type of code, which combines functions (or classes) and checks within the functions that handle messy data, will make your code easier to maintain over time. 
 
 :::{tip}
 Using functions, classes, and methods (functions within a class) is a great first step in handling messy data. A function or method provides a modular unit you can test outside of the workflow for the edge cases you may encounter. Also, because a function is a modular unit, you can add elements to handle unexpected processing features as you build your workflow.
+
+Once you have these functions and methods, you can add checks using conditional statements and try/except blocks that anticipate edge cases and errors that you may encounter when processing your data. 
 :::
 
-something about debuggers? 
-* https://jupyterlab.readthedocs.io/en/stable/user/debugger.html
+<!-- From JEREMY: Two suggestions I have for this lesson:
+encourage attendees to "fail fast"
+only when it is unrecoverable
+this makes the failure happen earlier, wasting less time waiting
+this can make the stack trace more useful, as it points the the code experiencing the error
+
+clearly describe the error.
+rather than just printing out "exiting now", try to tell the caller why it was a mistake, and what they could maybe do to fix it.
+maybe also explain that exceptions can (most of the time) take a message string, and it doesn't have to be printed also. -->
 
 ## Manage the unexpected 
 
-In this activity, you will apply the following strategies:
+In this activity, you will apply the following strategies to make your code more robust,  maintainable & usable:
 
-* [conditional statements](../checks-conditionals/python-conditionals)
-* try/except blocks
+* Fail fast strategy: more here
+* Use [conditional statements](../checks-conditionals/python-conditionals) and/or try/except blocks to catch errors and return useful output
 
 to process the JOSS citation data. 
 
@@ -110,6 +119,10 @@ Your goal is to make the code below run on the data provided in the activity-3 `
 
 :::{tip}
 The code below will fail. You will likely want to use a debugger to determine why it's failing and get the code running. 
+
+* If you are using Jupyter, then you might [find this page helpful when setting up debugging.](https://jupyterlab.readthedocs.io/en/stable/user/debugger.html)
+* VSCODE has a nice visual debugger that you can use.
+
 :::
 
 The code below is an example of what your code might look like after completing activity 2. You can choose to work with this code, or you can use the code that you completed in activity 2.
@@ -233,7 +246,7 @@ Ideas for on your own welcome!
 Ideas welcome?
 :::
 
-I want to have them move their code into a module if possible during this workshop but we could also kick that off in the day 2 workshop. 
+I want to have them move their code into a module if possible during this workshop but we could also kick that off in the day 2 workshop.
 
 ```{code-cell} ipython3
 ---

--- a/clean-modular-code/activity-3/clean-code-activity-3.md
+++ b/clean-modular-code/activity-3/clean-code-activity-3.md
@@ -13,27 +13,28 @@ kernelspec:
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
+(clean-code-activity-3)=
 # Activity 3: Tests & Checks for your code
 
-* In [activity 1](../activity-1/clean-code-activity-1), you made your code cleaner and more usable using expressive variable names and docstrings to document the module. 
-* In [activity 2](../activity-2/clean-code-activity-2), you made your code more DRY ("Don't Repeat Yourself") using documented functions and conditionals. 
+* In [activity 1](../activity-1/clean-code-activity-1), you made your code cleaner and more usable using [expressive variable names](python-expressive) and docstrings to document the module. 
+* In [activity 2](../activity-2/clean-code-activity-2), you made your code more DRY ("Don't Repeat Yourself") using documented [functions](write-functions) and [conditionals](python-conditionals). 
 
-In this activity, you will build checks into your workflow to handle data processing "features".
+In this activity, you will build checks into your workflow using [try/except](try-except) blocks added to functions to handle data processing "features".
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
 ### Real world data processing & workflows and edge cases 
 
-Real-world data rarely can be imported without "work arounds". You will often find unusual data entries and values you don't expect. Sometimes, these values are documented - for example, a 9999 may represent a missing value in a dataset. Other times, there are typos and other errors in the data that you need to handle. These unusual values or instances in a dataset or workflow are sometimes called "edge cases".  
+Real-world data rarely can be imported without "work-arounds". You will often find unusual data entries and values you don't expect. Sometimes, these values are documented - for example, a `9999` may represent a missing value in a dataset. Other times, there are typos and other errors in the data that you need to handle. These unusual values or instances in a dataset or workflow are sometimes called "edge cases".  
 
 Writing robust code that handles unexpected values will make your code run smoothly and fail gracefully. This type of code, which combines functions (or classes) and checks within the functions that handle messy data, will make your code easier to maintain.
 
-Things like helpful error messages and fast failing will also improve the experience for someone else using your code - OR your future self. 
+Things like helpful error messages and fast failing will also improve the experience for someone else using your code--OR your future self. 
  
 :::{tip}
 Using functions, classes, and methods (functions within a class) is a great first step in handling messy data. A function or method provides a modular unit you can test outside of the workflow for the edge cases you may encounter. Also, because a function is a modular unit, you can add elements to handle unexpected processing features as you build your workflow.
 
-Once you have these functions and methods, you can add checks using conditional statements and try/except blocks that anticipate edge cases and errors that you may encounter when processing your data. 
+Once you have these functions and methods, you can add checks using conditional statements and [try/except](try-except) blocks that anticipate edge cases and errors that you may encounter when processing your data. 
 :::
 
 ## Manage the unexpected 
@@ -50,7 +51,7 @@ In this activity, you will apply the following strategies to make your code more
   you to handle potential errors by attempting an operation and catching any 
   exceptions if they occur, providing useful feedback. In some cases you may want the program to end on an error. In other cases, you may want to handle it in a specific way. 
 
-When you can, try to use a [Pythonic approach](pythonic-checks) to catch errors early; this means asking for forgiveness later (often using try/except blocks) vs. using conditional statements to check an object's state or type.
+Try to use a [Pythonic approach](pythonic-checks) to catch errors early when completing this activity. This means asking for forgiveness later vs. using conditional statements to check an object's state or type.
 
 ```{code-cell} ipython3
 ---
@@ -67,13 +68,14 @@ def clean_title(title):
     return title
 ```
 
-The function below raises an error with a custom error message. but you can still see the 
+The function below raises an error with a custom error message.
 
 ```{code-cell} ipython3
 ---
 editable: true
 slideshow:
   slide_type: ''
+tags: [raises-exception]
 ---
 # This is the preferred way to catch an error 
 def clean_title(title):
@@ -110,6 +112,8 @@ title = ""
 print(clean_title(title))  # This will raise an IndexError with the friendly message
 ```
 
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
 If you wish, you can shorten the amount of information returned in the exception by adding `from None` to your exception. This will look nicer to a user but you lose some information in the exception feedback. 
 
 ```{code-cell} ipython3
@@ -136,7 +140,7 @@ print(clean_title(title))  # This will raise an IndexError with the friendly mes
 In this activity, you will be working with Pandas dataframes. You may find the .apply function to be particularly useful. 
 
 :::{tip}
-### Applying functions to DataFrame values--`.apply` 
+### Applying functions to DataFrame values: `.apply` 
 
 The `.apply()` function in pandas allows you to apply any function to rows or columns in a `pandas.DataFrame`. For example, you can use it to perform operations on specific column or row values. When you use `.apply()`, you can specify whether you want to apply the function across columns `(axis=0)` (the default) or across rows `(axis=1)`. 
 
@@ -355,14 +359,6 @@ print("Final shape of combined DataFrame:", all_papers_df.shape)
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
-## What i don't like
-
-What I don't like about this is that the file not found error isn't too bad to figure out. things like keyerrors and value errors are more amorphous. so this could be an OYO 2 
-
-and we could work through a index error or a key error instead?  Becuase in that case they may want to return a default value or something else....
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
 :::{admonition} Part 1 - What happens when your code can't find the data?
 :class: attention
 
@@ -442,14 +438,32 @@ Note: we can have two groups - one that wants to work on their own and another t
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
-:::{admonition} On your own 1
+:::{admonition} Activity 3: part 1 
 :class: attention
 
-What happens 
+In this activity, we will work together in groups or as a whole class to add a try/except block that handles messiness when parsing titles in the cross-ref data. 
 
 :::
 
-I want to have them move their code into a module if possible during this workshop but we could also kick that off in the day 2 workshop.
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+:::{admonition} On your own 1
+:class: attention
+
+If you get through the activity above and want a second challenge, try to parse the date values for each JOSS publication. Use the published key to extract the date for each publication. You may run into some data "features" when completing this activity. 
+
+```json
+"published": {
+      "date-parts": [
+        [
+          2020,
+          7,
+          4
+        ]
+      ]
+```
+
+:::
 
 ```{code-cell} ipython3
 ---

--- a/clean-modular-code/checks-conditionals/about-python-functions.md
+++ b/clean-modular-code/checks-conditionals/about-python-functions.md
@@ -45,7 +45,7 @@ print(x)
 Functions can help you to both eliminate repetition and improve efficiency by making it more modular. 
 
 
-Modulare code is code that is separated into independent units that can be reused and even combined to complete a longer chain of tasks.
+Modular code is separated into independent units that can be reused and even combined to complete a longer chain of tasks.
 
 :::{figure} ../images/clean-code/functions-for-all-things.png
 :alt: You can implement strategies such as loops and functions in your code to replace tasks that you are performing over and over. Source: Francois Michonneau.
@@ -93,7 +93,7 @@ When you write modular functions, you can reuse them for other workflows and pro
 When coding tasks step by step, you are likely creating many intermediate variables that are not needed again but are
 stored in your computer's memory.
 
-By using functions, these intermediate variables are confined to the function’s local scope. Once the function finishes executing, the variables created within the function are discarded making your code cleaner and more efficient  
+These intermediate variables are confined to the function’s local scope by using functions. Once the function finishes executing, the variables created within the function are discarded, making your code cleaner and more efficient  
 
 ## Reasons why functions improve code readability
 
@@ -122,7 +122,7 @@ Organizing your code using functions from the beginning allows you to explicitly
 
 ### Functions and tests  
 
-While you will not learn about testing in this lesson, functions are also useful for testing.
+Functions are also useful for testing.
 
 As your code gets longer and more complex, it is more prone to mistakes. For example, if your analysis relies on data that gets updated often, you may want to make sure that all data are up-to-date before performing an analysis. Or that the new data are not formatted in a different way.
 

--- a/clean-modular-code/checks-conditionals/python-common-exceptions.md
+++ b/clean-modular-code/checks-conditionals/python-common-exceptions.md
@@ -1,0 +1,169 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.4
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+(common-exceptions)=
+### Common Python exceptions 
+
+Python has dozens of specific errors that can be raised when code fails to run. Below are a few common ones that you may encounter in [Activity 3](clean-code-activity-3). 
+	
+### TypeError
+
+Occurs when an operation is applied to an object of an inappropriate type.
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+# Example: Trying to add a number and a string
+1 + 'string'  # This will raise a TypeError
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+#### ValueError
+
+- **Raised when** a function receives an argument of the right type but an invalid value.
+- **Example:** `int('abc')` (trying to convert an invalid string to an integer).
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+int("abc")
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+#### KeyError
+
+- **Raised when** a dictionary key is not found.
+- **Example:** `my_dict['nonexistent_key']` (trying to access a key that doesn’t exist in the dictionary).
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+# Example: Accessing a nonexistent key in a dictionary
+my_dict = {"a": 1, "b": 2}
+my_dict['nonexistent_key']
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+#### IndexError:
+
+- **Raised when** an invalid index is used to access a list or tuple.
+- **Example:** `my_list[10]` (trying to access the 11th element of a list with fewer elements).
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+my_list = [1, 2, 3]
+my_list[10] 
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+#### AttributeError:
+
+Raised when an object does not have a specific attribute or method.
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+my_string = "Hello"
+my_string.nonexistent_method()
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+#### FileNotFoundError
+
+A `FileNotFoundError` occurs in Python when the code attempts to open or access a file that does not exist at the specified path.
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+with open("data/nonexistent_file.json", "r") as file:
+    data = file.read()
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+By catching this exception, you can 
+
+1. Raise a kinder and more informative message.
+2. Direct the user toward the next steps
+3. FUTURE: write tests for this step of the workflow (if you are creating a package!) that make sure that it handles a bad file path properly.
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+from pathlib import Path
+
+file_path = Path("data") / "nonexistent_file.json"
+try:
+    with open(file_path, "r") as file:
+        data = file.read()
+except FileNotFoundError as fe:
+    raise FileNotFoundError(f"Oops! it looks like you provided a path to a file that doesn't exist. You provided: {file_path}. Make sure the file path exists. ")
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+If you don't raise the error but instead provide a print statement, you can provide a simple, clean output without the full "stack" or set of Python messages that provides the full "tracking" or traceback of where the error originated. 
+
+The challenge with not raising a FileNotFound error is that it will be a bit trickier to test the output. 
+
+* you could do `sys.exit` too... bbut i've ru into issues with that in the past (i wish i could remember what they were ) .
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+---
+file_path = Path("data") / "nonexistent_file.json"
+try:
+    with open(file_path, "r") as file:
+        data = file.read()
+except FileNotFoundError as fe:
+    print(f"Oops! it looks like you provided a path to a file that doesn't exist. You provided: {file_path}. Make sure the file path exists. ")
+```

--- a/clean-modular-code/checks-conditionals/python-conditionals.md
+++ b/clean-modular-code/checks-conditionals/python-conditionals.md
@@ -18,6 +18,7 @@ jupyter:
     name: python3
 ---
 
+(python-conditionals)=
 # Conditional statements in Python
 
 While there are many strategies for improving efficiency and removing repetition in code, three commonly used DRY strategies are conditional statements, loops, and functions.

--- a/clean-modular-code/checks-conditionals/python-function-checks.md
+++ b/clean-modular-code/checks-conditionals/python-function-checks.md
@@ -30,7 +30,188 @@ Your goal is to identify detect and data processing or workflow problems immedia
 them to propagate through your code. This approach saves time and makes
 debugging easier, providing clearer, more useful error outputs (known as stack traces).
 
-When working with messy data, you'll often encounter edge cases - unusual or unexpected data that can break your processing pipeline. Functions allow you to implement robust error handling and data validation. Here are some techniques you can use
+When working with messy data, you'll often encounter edge cases - unusual or unexpected data that can break your processing pipeline. Functions allow you to implement robust error handling and data validation.
+
+(fail-fast)=
+
+## Fail fast strategy
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+# Open a file (but it doesn't exist
+def read_file(file_path):
+    with open(file_path, 'r') as file:
+        data = file.read()
+    return data
+
+file_data = read_file("nonexistent_file.txt")
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+In the example below, you use a [conditional statement](python-conditionals) to check to see if the file exists; if it doesn't, then it returns None. In this case the code will fail quietly and the user doesn't understand that there is an error.
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+---
+import os
+
+def read_file(file_path):
+    if os.path.exists(file_path):
+        with open(file_path, 'r') as file:
+            data = file.read()
+        return data
+    else:
+        return None  # Doesn't fail immediately, just returns None
+
+# No error raised, even though the file doesn't exist
+file_data = read_file("nonexistent_file.txt")
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+This code example below is better than the examples above for three reasons:
+
+1. It's pythonic: it asks for forgiveness later by using a try/except
+2. it fails quickly - as soon as it tries to open the file. The code won't continue to run after this step fails.
+3. it raises a clean, useful error that the user can undersatnd
+
+The code anticipates what will happen if it can't find the file. Here you can raise a `FileNotFoundError` and provide a useful message to the user.
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+def read_file(file_path):
+    try:
+        with open(file_path, 'r') as file:
+            data = file.read()
+        return data
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Oops! I couldn't find the file located at: {file_path}. Please check to see if it exists")
+
+# Raises an error immediately if the file doesn't exist
+file_data = read_file("nonexistent_file.txt")
+```
+
+Notice that the code below doesn't throw an error. This code is allowed to fail quietly.
+This will be problematic for a user as their code will run but they will have no output and will have to carefully debug the code in order to figure out where the problem is.
+
+```{code-cell} ipython3
+from pathlib import Path
+
+def read_file(file_path):
+    """
+    Reads the content of a single file and returns it.
+    Handles errors if the file cannot be read.
+    """
+    try:
+        with open(file_path, 'r') as file:
+            data = file.read()
+            return data
+    except FileNotFoundError:
+        return f"File not found: {file_path}"
+    except Exception as e:
+        return f"An error occurred while reading {file_path}: {e}"
+
+# Example usage
+directory_path = Path("data")
+files = list(directory_path.glob("*.json"))
+for file in files:
+    file_data = read_file(file)
+    print(f"Content of {file.name}:")
+    print(file_data)
+print("All done--I didn't fail but I should have failed quickly")
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+[Using functions](python-functions) is a great first step in creating a robust
+and maintainable data processing workflow. Functions provide modular units that
+can be tested independently, allowing you to handle various edge cases and
+unexpected scenarios effectively. However, adding checks to your functions
+is the next step towards making your code more robust and maintainable over time.
+
+(pythonic-checks)=
+
+## Make Checks Pythonic
+
+Python has a unique philosophy regarding handling potential errors or
+exceptional cases. This philosophy is often summarized by the acronym EAFP:
+"Easier to Ask for Forgiveness than Permission." When combined with the **fail
+fast** approach, your code can be flexible and resilient to the messy
+realities of data processing.
+
+### EAFP vs. LBYL
+
+There are two main approaches to handling potential errors:
+
+- **LBYL (Look Before You Leap)**: Check for conditions before making calls or
+  accessing data.
+- **EAFP (Easier to Ask for Forgiveness than Permission)**: Assume the operation
+  will succeed and handle any exceptions if they occur.
+
+Pythonic code generally favors the EAFP approach, which allows for **failing
+fast** when an error occurs, providing useful feedback without unnecessary
+checks.
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+---
+# LBYL approach - manually check that the user provides a int
+def convert_to_int(value):
+    if isinstance(value, int):
+        return int(value)
+    else:
+        print("Oops i can't process this so I will fail gracefully.")
+        return None 
+
+convert_to_int(1)
+convert_to_int("a")
+```
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+---
+# EAFP approach - Consider what the user might provide and catch the error. 
+def convert_to_int(value):
+    try:
+        return int(value)
+    except ValueError:
+        print("Oops i can't process this so I will fail gracefully.")
+        return None  # or some default value
+
+convert_to_int(1)
+convert_to_int("a")
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+The EAFP (Easier to Ask for Forgiveness than Permission) approach is more Pythonic because:
+
+- It’s often faster, avoiding redundant checks when operations succeed.
+- It’s more readable, separating the intended operation and error handling.
+
+## Any Check is a Good Check
+
+As long as you consider edge cases, you're writing great code! You don’t need to worry about being “Pythonic” immediately, but understanding both approaches is useful regardless of which approach you chose.
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
@@ -57,7 +238,7 @@ def convert_to_int(value):
     try:
         return int(value)
     except ValueError:
-        print("Oops i can't process this so I will fail gracefully.")
+        print("Oops i can't process this so I will fail quietly with a print statement.")
         return None  # or some default value
 ```
 
@@ -233,6 +414,70 @@ tags: [raises-exception]
 ---
 my_string = "Hello"
 my_string.nonexistent_method()
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+## FileNotFoundError
+
+A `FileNotFoundError` occurs in Python when the code attempts to open or access a file that does not exist at the specified path.
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+with open("data/nonexistent_file.json", "r") as file:
+    data = file.read()
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+By catching this exception, you can
+
+1. Raise a kinder and more informative message.
+2. Direct the user toward the next steps
+3. FUTURE: write tests for this step of the workflow (if you are creating a package!) that make sure that it handles a bad file path properly.
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+from pathlib import Path
+
+file_path = Path("data") / "nonexistent_file.json"
+try:
+    with open(file_path, "r") as file:
+        data = file.read()
+except FileNotFoundError as fe:
+    raise FileNotFoundError(f"Oops! it looks like you provided a path to a file that doesn't exist. You provided: {file_path}. Make sure the file path exists. ")
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+If you don't raise the error but instead provide a print statement, you can provide a simple, clean output without the full "stack" or set of Python messages that provides the full "tracking" or traceback of where the error originated.
+
+The challenge with not raising a FileNotFound error is that it will be a bit trickier to test the output.
+
+- you could do `sys.exit` too... bbut i've ru into issues with that in the past (i wish i could remember what they were ) .
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+---
+file_path = Path("data") / "nonexistent_file.json"
+try:
+    with open(file_path, "r") as file:
+        data = file.read()
+except FileNotFoundError as fe:
+    print(f"Oops! it looks like you provided a path to a file that doesn't exist. You provided: {file_path}. Make sure the file path exists. ")
 ```
 
 ```{code-cell} ipython3

--- a/clean-modular-code/checks-conditionals/python-function-checks.md
+++ b/clean-modular-code/checks-conditionals/python-function-checks.md
@@ -12,6 +12,11 @@ kernelspec:
 ---
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
+<<<<<<< HEAD
+=======
+
+# Write Flexible Functions to Handle Messy Data
+>>>>>>> 06028c1 (fix: more code fixes - activity 3)
 
 # Write Flexible Functions for Messy Data
 
@@ -30,7 +35,158 @@ Your goal is to identify detect and data processing or workflow problems immedia
 them to propagate through your code. This approach saves time and makes
 debugging easier, as it provides clearer, more useful error outputs (known as stack traces).
 
+<<<<<<< HEAD
 When working with messy data, you'll often encounter edge cases - unusual or unexpected data that can break your processing pipeline. Functions allow you to implement robust error handling and data validation. Here are some techniques you can use
+=======
+(fail-fast)=
+## Fail fast strategy
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+# Open a file (but it doesn't exist
+def read_file(file_path):
+    with open(file_path, 'r') as file:
+        data = file.read()
+    return data
+
+file_data = read_file("nonexistent_file.txt")
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+In the example below, you use a [conditional statement](python-conditionals) to check to see if the file exists; if it doesn't, then it returns None. In this case the code will fail quietly and the user doesn't understand that there is an error. 
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+---
+import os
+
+def read_file(file_path):
+    if os.path.exists(file_path):
+        with open(file_path, 'r') as file:
+            data = file.read()
+        return data
+    else:
+        return None  # Doesn't fail immediately, just returns None
+
+# No error raised, even though the file doesn't exist
+file_data = read_file("nonexistent_file.txt")
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+This code example below is better than the examples above for three reasons:
+
+1. It's pythonic: it asks for forgiveness later by using a try/except
+2. it fails quickly - as soon as it tries to open the file. The code won't continue to run after this step fails.
+3. it raises a clean, useful error that the user can undersatnd
+is an example of Pythonic code. Here, a file is read in and
+
+The code anticipates what will happen if it can't find the file. Here you can raise a `FileNotFoundError` and provide a useful message to the user. 
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+tags: [raises-exception]
+---
+def read_file(file_path):
+    try:
+        with open(file_path, 'r') as file:
+            data = file.read()
+        return data
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"Oops! I could find the file located at: {file_path}. Please check to see if it exists")
+
+# Raises an error immediately if the file doesn't exist
+file_data = read_file("nonexistent_file.txt")
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+[Using functions](python-functions) is a great first step in creating a robust
+and maintainable data processing workflow. Functions provide modular units that
+can be tested independently, allowing you to handle various edge cases and
+unexpected scenarios effectively.
+
+(pythonic-checks)=
+## Make Checks Pythonic
+
+Python has a unique philosophy regarding handling potential errors or
+exceptional cases. This philosophy is often summarized by the acronym EAFP:
+"Easier to Ask for Forgiveness than Permission." When combined with the **fail
+fast** approach, your code can be both flexible and resilient to the messy
+realities of data processing.
+
+### EAFP vs. LBYL
+
+There are two main approaches to handling potential errors:
+
+- **LBYL (Look Before You Leap)**: Check for conditions before making calls or
+  accessing data.
+- **EAFP (Easier to Ask for Forgiveness than Permission)**: Assume the operation
+  will succeed and handle any exceptions if they occur.
+
+Pythonic code generally favors the EAFP approach, which allows for **failing
+fast** when an error occurs, providing useful feedback without unnecessary
+checks.
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+---
+# LBYL approach - manually check that the user provides a int
+def convert_to_int(value):
+    if isinstance(value, int):
+        return int(value)
+    else:
+        print("Oops i can't process this so I will fail gracefully.")
+        return None 
+
+convert_to_int(1)
+convert_to_int("a")
+```
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+---
+# EAFP approach - Consider what the user might provide and catch the error. 
+def convert_to_int(value):
+    try:
+        return int(value)
+    except ValueError:
+        print("Oops i can't process this so I will fail gracefully.")
+        return None  # or some default value
+
+convert_to_int(1)
+convert_to_int("a")
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+The EAFP (Easier to Ask for Forgiveness than Permission) approach is more Pythonic because:
+
+* It’s often faster, avoiding redundant checks when operations succeed.
+* It’s more readable, separating the intended operation and error handling.
+
+## Any Check is a Good Check
+
+As long as you consider edge cases, you're writing great code! You don’t need to worry about being “Pythonic” immediately, but understanding both approaches is useful regardless of which approach you chose.
+>>>>>>> 06028c1 (fix: more code fixes - activity 3)
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 

--- a/clean-modular-code/checks-conditionals/python-function-checks.md
+++ b/clean-modular-code/checks-conditionals/python-function-checks.md
@@ -26,9 +26,11 @@ Using functions in your data processing pipeline offers several advantages:
 3. **Flexibility**: As you build out your workflow, you can easily add elements to functions to handle new processing requirements or edge cases.
 4. **Reusability**: Well-designed functions can be reused across different parts of your project or even in other projects.
 
-## Handling edge cases
+Your goal is to identify detect and data processing or workflow problems immediately when they occur, rather than allowing
+them to propagate through your code. This approach saves time and makes
+debugging easier, as it provides clearer, more useful error outputs (known as stack traces).
 
-When working with messy data, you'll often encounter edge cases - unusual or unexpected data that can break your processing pipeline. Functions allow you to implement robust error handling and data validation. Here are some techniques you can use:
+When working with messy data, you'll often encounter edge cases - unusual or unexpected data that can break your processing pipeline. Functions allow you to implement robust error handling and data validation. Here are some techniques you can use
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
@@ -134,8 +136,8 @@ convert_to_int("a")
 
 The EAFP (Easier to Ask for Forgiveness than Permission) approach is more Pythonic because:
 
-* It’s often faster, avoiding redundant checks when operations succeed.
-* It’s more readable, separating the intended operation and error handling.
+- It’s often faster, avoiding redundant checks when operations succeed.
+- It’s more readable, separating the intended operation and error handling.
 
 ## Any Check is a Good Check
 
@@ -146,7 +148,7 @@ As long as you consider edge cases, you're writing great code! You don’t need 
 ## Common Python exceptions
 
 Python has dozens of specific errors that can be raised when code fails to run. Below are a few common ones that you may encounter in the activity 3.
- 
+
 ### TypeError
 
 Occurs when an operation is applied to an object of an inappropriate type.
@@ -166,8 +168,8 @@ tags: [raises-exception]
 
 ### ValueError
 
-* **Raised when** a function receives an argument of the right type but an invalid value.
-* **Example:** `int('abc')` (trying to convert an invalid string to an integer).
+- **Raised when** a function receives an argument of the right type but an invalid value.
+- **Example:** `int('abc')` (trying to convert an invalid string to an integer).
 
 ```{code-cell} ipython3
 ---
@@ -183,8 +185,8 @@ int("abc")
 
 ### KeyError
 
-* **Raised when** a dictionary key is not found.
-* **Example:** `my_dict['nonexistent_key']` (trying to access a key that doesn’t exist in the dictionary).
+- **Raised when** a dictionary key is not found.
+- **Example:** `my_dict['nonexistent_key']` (trying to access a key that doesn’t exist in the dictionary).
 
 ```{code-cell} ipython3
 ---
@@ -202,8 +204,8 @@ my_dict['nonexistent_key']
 
 ### IndexError
 
-* **Raised when** an invalid index is used to access a list or tuple.
-* **Example:** `my_list[10]` (trying to access the 11th element of a list with fewer elements).
+- **Raised when** an invalid index is used to access a list or tuple.
+- **Example:** `my_list[10]` (trying to access the 11th element of a list with fewer elements).
 
 ```{code-cell} ipython3
 ---

--- a/clean-modular-code/checks-conditionals/python-function-checks.md
+++ b/clean-modular-code/checks-conditionals/python-function-checks.md
@@ -31,7 +31,7 @@ Using functions in your data processing pipeline offers several advantages:
 3. **Flexibility**: As you build out your workflow, you can easily add elements to functions to handle new processing requirements or edge cases.
 4. **Reusability**: Well-designed functions can be reused across different parts of your project or even in other projects.
 
-Your goal is to identify detect and data processing or workflow problems immediately when they occur, rather than allowing
+Your goal is to identify data processing or workflow problems immediately when they occur, rather than allowing
 them to propagate through your code. This approach saves time and makes
 debugging easier, as it provides clearer, more useful error outputs (known as stack traces).
 
@@ -88,7 +88,6 @@ This code example below is better than the examples above for three reasons:
 1. It's pythonic: it asks for forgiveness later by using a try/except
 2. it fails quickly - as soon as it tries to open the file. The code won't continue to run after this step fails.
 3. it raises a clean, useful error that the user can undersatnd
-is an example of Pythonic code. Here, a file is read in and
 
 The code anticipates what will happen if it can't find the file. Here you can raise a `FileNotFoundError` and provide a useful message to the user. 
 
@@ -104,8 +103,8 @@ def read_file(file_path):
         with open(file_path, 'r') as file:
             data = file.read()
         return data
-    except FileNotFoundError as e:
-        raise FileNotFoundError(f"Oops! I could find the file located at: {file_path}. Please check to see if it exists")
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Oops! I couldn't find the file located at: {file_path}. Please check to see if it exists")
 
 # Raises an error immediately if the file doesn't exist
 file_data = read_file("nonexistent_file.txt")

--- a/clean-modular-code/checks-conditionals/python-function-checks.md
+++ b/clean-modular-code/checks-conditionals/python-function-checks.md
@@ -28,7 +28,7 @@ Using functions in your data processing pipeline offers several advantages:
 
 Your goal is to identify detect and data processing or workflow problems immediately when they occur, rather than allowing
 them to propagate through your code. This approach saves time and makes
-debugging easier, as it provides clearer, more useful error outputs (known as stack traces).
+debugging easier, providing clearer, more useful error outputs (known as stack traces).
 
 When working with messy data, you'll often encounter edge cases - unusual or unexpected data that can break your processing pipeline. Functions allow you to implement robust error handling and data validation. Here are some techniques you can use
 

--- a/clean-modular-code/checks-conditionals/python-function-checks.md
+++ b/clean-modular-code/checks-conditionals/python-function-checks.md
@@ -12,11 +12,6 @@ kernelspec:
 ---
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
-<<<<<<< HEAD
-=======
-
-# Write Flexible Functions to Handle Messy Data
->>>>>>> 06028c1 (fix: more code fixes - activity 3)
 
 # Write Flexible Functions for Messy Data
 
@@ -31,161 +26,11 @@ Using functions in your data processing pipeline offers several advantages:
 3. **Flexibility**: As you build out your workflow, you can easily add elements to functions to handle new processing requirements or edge cases.
 4. **Reusability**: Well-designed functions can be reused across different parts of your project or even in other projects.
 
-Your goal is to identify data processing or workflow problems immediately when they occur, rather than allowing
+Your goal is to identify detect and data processing or workflow problems immediately when they occur, rather than allowing
 them to propagate through your code. This approach saves time and makes
 debugging easier, as it provides clearer, more useful error outputs (known as stack traces).
 
-<<<<<<< HEAD
 When working with messy data, you'll often encounter edge cases - unusual or unexpected data that can break your processing pipeline. Functions allow you to implement robust error handling and data validation. Here are some techniques you can use
-=======
-(fail-fast)=
-## Fail fast strategy
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
-tags: [raises-exception]
----
-# Open a file (but it doesn't exist
-def read_file(file_path):
-    with open(file_path, 'r') as file:
-        data = file.read()
-    return data
-
-file_data = read_file("nonexistent_file.txt")
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-In the example below, you use a [conditional statement](python-conditionals) to check to see if the file exists; if it doesn't, then it returns None. In this case the code will fail quietly and the user doesn't understand that there is an error. 
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
----
-import os
-
-def read_file(file_path):
-    if os.path.exists(file_path):
-        with open(file_path, 'r') as file:
-            data = file.read()
-        return data
-    else:
-        return None  # Doesn't fail immediately, just returns None
-
-# No error raised, even though the file doesn't exist
-file_data = read_file("nonexistent_file.txt")
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-This code example below is better than the examples above for three reasons:
-
-1. It's pythonic: it asks for forgiveness later by using a try/except
-2. it fails quickly - as soon as it tries to open the file. The code won't continue to run after this step fails.
-3. it raises a clean, useful error that the user can undersatnd
-
-The code anticipates what will happen if it can't find the file. Here you can raise a `FileNotFoundError` and provide a useful message to the user. 
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
-tags: [raises-exception]
----
-def read_file(file_path):
-    try:
-        with open(file_path, 'r') as file:
-            data = file.read()
-        return data
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Oops! I couldn't find the file located at: {file_path}. Please check to see if it exists")
-
-# Raises an error immediately if the file doesn't exist
-file_data = read_file("nonexistent_file.txt")
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-[Using functions](python-functions) is a great first step in creating a robust
-and maintainable data processing workflow. Functions provide modular units that
-can be tested independently, allowing you to handle various edge cases and
-unexpected scenarios effectively.
-
-(pythonic-checks)=
-## Make Checks Pythonic
-
-Python has a unique philosophy regarding handling potential errors or
-exceptional cases. This philosophy is often summarized by the acronym EAFP:
-"Easier to Ask for Forgiveness than Permission." When combined with the **fail
-fast** approach, your code can be both flexible and resilient to the messy
-realities of data processing.
-
-### EAFP vs. LBYL
-
-There are two main approaches to handling potential errors:
-
-- **LBYL (Look Before You Leap)**: Check for conditions before making calls or
-  accessing data.
-- **EAFP (Easier to Ask for Forgiveness than Permission)**: Assume the operation
-  will succeed and handle any exceptions if they occur.
-
-Pythonic code generally favors the EAFP approach, which allows for **failing
-fast** when an error occurs, providing useful feedback without unnecessary
-checks.
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
----
-# LBYL approach - manually check that the user provides a int
-def convert_to_int(value):
-    if isinstance(value, int):
-        return int(value)
-    else:
-        print("Oops i can't process this so I will fail gracefully.")
-        return None 
-
-convert_to_int(1)
-convert_to_int("a")
-```
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
----
-# EAFP approach - Consider what the user might provide and catch the error. 
-def convert_to_int(value):
-    try:
-        return int(value)
-    except ValueError:
-        print("Oops i can't process this so I will fail gracefully.")
-        return None  # or some default value
-
-convert_to_int(1)
-convert_to_int("a")
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-The EAFP (Easier to Ask for Forgiveness than Permission) approach is more Pythonic because:
-
-* It’s often faster, avoiding redundant checks when operations succeed.
-* It’s more readable, separating the intended operation and error handling.
-
-## Any Check is a Good Check
-
-As long as you consider edge cases, you're writing great code! You don’t need to worry about being “Pythonic” immediately, but understanding both approaches is useful regardless of which approach you chose.
->>>>>>> 06028c1 (fix: more code fixes - activity 3)
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 

--- a/clean-modular-code/checks-conditionals/python-function-checks.md
+++ b/clean-modular-code/checks-conditionals/python-function-checks.md
@@ -11,30 +11,93 @@ kernelspec:
   name: python3
 ---
 
+# Write Flexible Functions to Handle Messy Data
+
+When dealing with messy or unpredictable data, ensuring your code
+It is important to handle errors early and gracefully. [Using functions](python-functions) 
+is a great first step in creating a robust
+and maintainable data processing workflow. Functions provide modular units that
+can be tested independently, allowing you to handle various edge cases and
+unexpected scenarios effectively. 
+
+Adding checks to your functions 
+is the next step towards making your code more robust and maintainable over time. 
+
+This lesson will cover several strategies for making this happen: 
+
+
+1. Use [`try/except blocks`](#try-except) rather than simply allowing errors to occur.
+1. [Make checks Pythonic](#pythonic-checks)
+1. [Fail fast](fail-fast)
+
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
-# Write Flexible Functions for Messy Data
+(try-except)=
+## Use Try/Except blocks
 
-When dealing with messy or unpredictable data, using functions is an excellent first step in creating a robust and maintainable data processing workflow. Functions provide modular units that can be tested independently, allowing you to handle various edge cases and unexpected scenarios effectively.
+`try/except` blocks in Python help you handle errors gracefully instead of letting your program crash. They are used when you think a part of your code might fail, like when working with missing data, or when converting data types.
 
-## Function benefits
+Here’s how try/except blocks work:
 
-Using functions in your data processing pipeline offers several advantages:
+* **try block:** You write the code that might cause an error here. Python will attempt to run this code.
+* **except block:** If Python encounters an error in the try block, it jumps to the except block to handle it. You can specify what to do when an error occurs, such as printing a friendly message or providing a fallback option.
 
-1. **Modularity**: Functions encapsulate specific tasks, making your code more organized and easier to understand.
-2. **Testability**: You can test functions individually, outside of the main workflow, to ensure they handle different scenarios correctly.
-3. **Flexibility**: As you build out your workflow, you can easily add elements to functions to handle new processing requirements or edge cases.
-4. **Reusability**: Well-designed functions can be reused across different parts of your project or even in other projects.
+A `try/except` block looks like this:
 
-Your goal is to identify detect and data processing or workflow problems immediately when they occur, rather than allowing
-them to propagate through your code. This approach saves time and makes
-debugging easier, providing clearer, more useful error outputs (known as stack traces).
+```python
+try:
+    # code that might cause an error
+except SomeError:
+    # what to do if there's an error
+```
 
-When working with messy data, you'll often encounter edge cases - unusual or unexpected data that can break your processing pipeline. Functions allow you to implement robust error handling and data validation.
+:::{tip}
+We pulled together some of the more [common exceptions that Python can throw here](common-exceptions). 
+:::
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+---
+def convert_to_int(value):
+    try:
+        return int(value)
+    except ValueError:
+        print("Oops i can't process this so I will fail quietly with a print statement.")
+        return None  # or some default value
+```
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+---
+convert_to_int("123")
+```
+
+```{code-cell} ipython3
+---
+editable: true
+slideshow:
+  slide_type: ''
+---
+convert_to_int("abc") 
+```
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
+
+This function attempts to convert a value to an integer, returning `None` and a message if the conversion fails. However, is that message helpful to a person using your code? 
+
++++ {"editable": true, "slideshow": {"slide_type": ""}}
 
 (fail-fast)=
-
 ## Fail fast strategy
+
+Identify data processing or workflow problems immediately when they occur and throw an error immediately rather than allowing
+them to propagate through your code. This approach saves time and simplifies debugging, providing clearer, more useful error outputs (stack traces).  Below, you can see that the code tries to open a file, but Python can't find the file. In response, Python throws a `FileNotFoundError`. 
 
 ```{code-cell} ipython3
 ---
@@ -54,7 +117,11 @@ file_data = read_file("nonexistent_file.txt")
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
-In the example below, you use a [conditional statement](python-conditionals) to check to see if the file exists; if it doesn't, then it returns None. In this case the code will fail quietly and the user doesn't understand that there is an error.
+You could anticipate a user providing a bad file path. This might be especailly possible if you plan to share your code with others and run it on different computers and different operating systems.
+
+In the example below, you use a [conditional statement](python-conditionals) to check if the file exists; if it doesn't, it returns None. In this case, the code will fail quietly, and the user will not understand that there is an error.
+
+This is also dangerous territory for a user who may not understand why the code runs but doesn't work.
 
 ```{code-cell} ipython3
 ---
@@ -80,11 +147,11 @@ file_data = read_file("nonexistent_file.txt")
 
 This code example below is better than the examples above for three reasons:
 
-1. It's pythonic: it asks for forgiveness later by using a try/except
-2. it fails quickly - as soon as it tries to open the file. The code won't continue to run after this step fails.
-3. it raises a clean, useful error that the user can undersatnd
+1. It's **pythonic**: it asks for forgiveness later by using a try/except
+2. It fails quickly - as soon as it tries to open the file. The code won't continue to run after this step fails.
+3. It raises a clean, useful error that the user can understand
 
-The code anticipates what will happen if it can't find the file. Here you can raise a `FileNotFoundError` and provide a useful message to the user.
+The code anticipates what will happen if it can't find the file. It then raises a `FileNotFoundError` and provides a useful and friendly message to the user.
 
 ```{code-cell} ipython3
 ---
@@ -99,52 +166,39 @@ def read_file(file_path):
             data = file.read()
         return data
     except FileNotFoundError:
-        raise FileNotFoundError(f"Oops! I couldn't find the file located at: {file_path}. Please check to see if it exists")
+        raise FileNotFoundError(f"Oops! I couldn't find the file located at: "
+                                f"{file_path}. Please check to see if it exists")
 
 # Raises an error immediately if the file doesn't exist
 file_data = read_file("nonexistent_file.txt")
 ```
 
-Notice that the code below doesn't throw an error. This code is allowed to fail quietly.
-This will be problematic for a user as their code will run but they will have no output and will have to carefully debug the code in order to figure out where the problem is.
+## Customizing error messages
+
+The code above is useful because it fails and provides a simple and effective message that tells the user to check that their file path is correct. 
+
+However, the amount of text returned from the error is significant because it finds the error when it can't open the file. Still, then you raise the error intentionally within the except statement. 
+
+If you wanted to provide less information to the user, you could use `from None`. From None ensure that you 
+only return the exception information related to the error that you handle within the try/except block. 
 
 ```{code-cell} ipython3
-from pathlib import Path
-
 def read_file(file_path):
-    """
-    Reads the content of a single file and returns it.
-    Handles errors if the file cannot be read.
-    """
     try:
         with open(file_path, 'r') as file:
             data = file.read()
-            return data
+        return data
     except FileNotFoundError:
-        return f"File not found: {file_path}"
-    except Exception as e:
-        return f"An error occurred while reading {file_path}: {e}"
+        raise FileNotFoundError(f"Oops! I couldn't find the file located at: {file_path}. "
+                                "Please check to see if it exists") from None
 
-# Example usage
-directory_path = Path("data")
-files = list(directory_path.glob("*.json"))
-for file in files:
-    file_data = read_file(file)
-    print(f"Content of {file.name}:")
-    print(file_data)
-print("All done--I didn't fail but I should have failed quickly")
+# Raises an error immediately if the file doesn't exist
+file_data = read_file("nonexistent_file.txt")
 ```
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
-[Using functions](python-functions) is a great first step in creating a robust
-and maintainable data processing workflow. Functions provide modular units that
-can be tested independently, allowing you to handle various edge cases and
-unexpected scenarios effectively. However, adding checks to your functions
-is the next step towards making your code more robust and maintainable over time.
-
 (pythonic-checks)=
-
 ## Make Checks Pythonic
 
 Python has a unique philosophy regarding handling potential errors or
@@ -206,279 +260,12 @@ convert_to_int("a")
 
 The EAFP (Easier to Ask for Forgiveness than Permission) approach is more Pythonic because:
 
-- It’s often faster, avoiding redundant checks when operations succeed.
-- It’s more readable, separating the intended operation and error handling.
+* It’s often faster, avoiding redundant checks when operations succeed.
+* It’s more readable, separating the intended operation and error handling.
 
 ## Any Check is a Good Check
 
 As long as you consider edge cases, you're writing great code! You don’t need to worry about being “Pythonic” immediately, but understanding both approaches is useful regardless of which approach you chose.
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-## Try/Except blocks
-
-Try/except blocks help you catch and handle errors that might happen while your code is running. This is useful for tasks that might fail, like converting data types or working with data that’s missing or incorrect.
-
-A try/except block looks like this:
-
-```python
-try:
-    # code that might cause an error
-except SomeError:
-    # what to do if there's an error
-```
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
----
-def convert_to_int(value):
-    try:
-        return int(value)
-    except ValueError:
-        print("Oops i can't process this so I will fail quietly with a print statement.")
-        return None  # or some default value
-```
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
----
-convert_to_int("123")
-```
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
----
-convert_to_int("abc") 
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-This function attempts to convert a value to an integer, returning None and a message if the conversion fails.
-
-## Make checks Pythonic
-
-Python has a unique philosophy regarding handling potential errors or exceptional cases. This philosophy is often summarized by the acronym EAFP: "Easier to Ask for Forgiveness than Permission."
-
-### EAFP vs. LBYL
-
-There are two main approaches to handling potential errors:
-
-**LBYL (Look Before You Leap)**: Check for conditions before making calls or accessing data.
-**EAFP (Easier to Ask for Forgiveness than Permission)**: Assume the operation will succeed and handle any exceptions if they occur.
-
-Pythonic code generally favors the EAFP approach.
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
----
-# LBYL approach - manually check that the user provides a int
-def convert_to_int(value):
-    if isinstance(value, int):
-        return int(value)
-    else:
-        print("Oops i can't process this so I will fail gracefully.")
-        return None 
-
-convert_to_int(1)
-convert_to_int("a")
-```
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
----
-# EAFP approach - Consider what the user might provide and catch the error. 
-def convert_to_int(value):
-    try:
-        return int(value)
-    except ValueError:
-        print("Oops i can't process this so I will fail gracefully.")
-        return None  # or some default value
-
-convert_to_int(1)
-convert_to_int("a")
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-The EAFP (Easier to Ask for Forgiveness than Permission) approach is more Pythonic because:
-
-- It’s often faster, avoiding redundant checks when operations succeed.
-- It’s more readable, separating the intended operation and error handling.
-
-## Any Check is a Good Check
-
-As long as you consider edge cases, you're writing great code! You don’t need to worry about being “Pythonic” immediately, but understanding both approaches is useful regardless of which approach you chose.
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-## Common Python exceptions
-
-Python has dozens of specific errors that can be raised when code fails to run. Below are a few common ones that you may encounter in the activity 3.
-
-### TypeError
-
-Occurs when an operation is applied to an object of an inappropriate type.
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
-tags: [raises-exception]
----
-# Example: Trying to add a number and a string
-1 + 'string'  # This will raise a TypeError
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-### ValueError
-
-- **Raised when** a function receives an argument of the right type but an invalid value.
-- **Example:** `int('abc')` (trying to convert an invalid string to an integer).
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
-tags: [raises-exception]
----
-int("abc")
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-### KeyError
-
-- **Raised when** a dictionary key is not found.
-- **Example:** `my_dict['nonexistent_key']` (trying to access a key that doesn’t exist in the dictionary).
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
-tags: [raises-exception]
----
-# Example: Accessing a nonexistent key in a dictionary
-my_dict = {"a": 1, "b": 2}
-my_dict['nonexistent_key']
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-### IndexError
-
-- **Raised when** an invalid index is used to access a list or tuple.
-- **Example:** `my_list[10]` (trying to access the 11th element of a list with fewer elements).
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
-tags: [raises-exception]
----
-my_list = [1, 2, 3]
-my_list[10] 
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-### AttributeError
-
-Raised when an object does not have a specific attribute or method.
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
-tags: [raises-exception]
----
-my_string = "Hello"
-my_string.nonexistent_method()
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-## FileNotFoundError
-
-A `FileNotFoundError` occurs in Python when the code attempts to open or access a file that does not exist at the specified path.
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
-tags: [raises-exception]
----
-with open("data/nonexistent_file.json", "r") as file:
-    data = file.read()
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-By catching this exception, you can
-
-1. Raise a kinder and more informative message.
-2. Direct the user toward the next steps
-3. FUTURE: write tests for this step of the workflow (if you are creating a package!) that make sure that it handles a bad file path properly.
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
-tags: [raises-exception]
----
-from pathlib import Path
-
-file_path = Path("data") / "nonexistent_file.json"
-try:
-    with open(file_path, "r") as file:
-        data = file.read()
-except FileNotFoundError as fe:
-    raise FileNotFoundError(f"Oops! it looks like you provided a path to a file that doesn't exist. You provided: {file_path}. Make sure the file path exists. ")
-```
-
-+++ {"editable": true, "slideshow": {"slide_type": ""}}
-
-If you don't raise the error but instead provide a print statement, you can provide a simple, clean output without the full "stack" or set of Python messages that provides the full "tracking" or traceback of where the error originated.
-
-The challenge with not raising a FileNotFound error is that it will be a bit trickier to test the output.
-
-- you could do `sys.exit` too... bbut i've ru into issues with that in the past (i wish i could remember what they were ) .
-
-```{code-cell} ipython3
----
-editable: true
-slideshow:
-  slide_type: ''
----
-file_path = Path("data") / "nonexistent_file.json"
-try:
-    with open(file_path, "r") as file:
-        data = file.read()
-except FileNotFoundError as fe:
-    print(f"Oops! it looks like you provided a path to a file that doesn't exist. You provided: {file_path}. Make sure the file path exists. ")
-```
 
 ```{code-cell} ipython3
 ---

--- a/clean-modular-code/checks-conditionals/python-functions-multi-parameters.md
+++ b/clean-modular-code/checks-conditionals/python-functions-multi-parameters.md
@@ -1,0 +1,608 @@
+---
+layout: single
+title: 'Write Functions with Multiple Parameters in Python'
+excerpt: "A function is a reusable block of code that performs a specific task. Learn how to write functions that can take multiple as well as optional parameters in Python to eliminate repetition and improve efficiency in your code."
+authors: ['Jenny Palomino', 'Leah Wasser']
+category: [courses]
+class-lesson: ['intro-functions-tb']
+permalink: /courses/intro-to-earth-data-science/write-efficient-python-code/functions-modular-code/write-functions-with-multiple-and-optional-parameters-in-python/
+nav-title: "Write Multi-Parameter Functions in Python"
+dateCreated: 2019-11-12
+modified: '{:%Y-%m-%d}'.format(datetime.now())
+module-type: 'class'
+chapter: 19
+course: "intro-to-earth-data-science-textbook"
+week: 7
+sidebar:
+  nav:
+author_profile: false
+comments: true
+order: 3
+topics:
+  reproducible-science-and-programming: ['python']
+redirect_from:
+  - "/courses/intro-to-earth-data-science/write-efficient-python-code/functions/write-functions-with-multiple-and-optional-parameters-in-python/"
+jupyter:
+  jupytext:
+    formats: ipynb,md
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.4
+  kernelspec:
+    display_name: Python 3 (ipykernel)
+    language: python
+    name: python3
+---
+
+<!-- #region -->
+{% include toc title="On This Page" icon="file-text" %}
+
+<div class='notice--success' markdown="1">
+
+## <i class="fa fa-graduation-cap" aria-hidden="true"></i> Learning Objectives
+
+* Write and execute custom functions with multiple input parameters in **Python**.
+* Write and execute custom functions with optional input parameters in **Python**. 
+ 
+</div>
+
+
+## How to Define a Function with Multiple Parameters in Python
+
+Previously in this textbook, you learned that an input parameter is the required information that you pass to the function for it to run successfully. The function will take the value or object provided as the input parameter and use it to perform some task.
+
+You also learned that in **Python**, the required parameter can be defined using a placeholder variable, such as `data`, which represents the value or object that will be acted upon in the function. 
+
+
+```python
+def function_name(data):
+```   
+
+However, sometimes you may need additional information for the function to run successfully.
+
+Luckily, you can write functions that take in more than one parameter by defining as many parameters as needed, for example: 
+
+```python
+def function_name(data_1, data_2):
+``` 
+
+When the function is called, a user can provide any value for `data_1` or `data_2` that the function can take as an input for that parameter (e.g. single value variable, list, **numpy** array, **pandas** dataframe column). 
+
+
+## Write a Function with Multiple Parameters in Python
+
+Imagine that you want to define a function that will take in two numeric values as inputs and return the product of these input values (i.e. multiply the values).  
+
+Begin with the `def` keyword and the function name, just as you have before to define a function:
+
+```python
+def multiply_values
+```
+
+Next, provide two placeholder variable names for the input parameters, as shown below. 
+
+```python
+def multiply_values(x,y):
+```
+
+Add the code to multiply the values and the `return` statement to returns the product of the two values: 
+
+```python
+def multiply_values(x,y):
+    z = x * y
+    return z
+```
+
+Last, write a docstring to provide the details about this function, including a brief description of the function (i.e. how it works, purpose) as well as identify the input parameters (i.e. type, description) and the returned output (i.e. type, description).
+<!-- #endregion -->
+```python
+def multiply_values(x,y):
+    """Calculate product of two inputs. 
+    
+    Parameters
+    ----------
+    x : int or float
+    y : int or float
+
+    Returns
+    ------
+    z : int or float
+    """
+    z = x * y
+    return z
+```
+
+## Call Custom Functions with Multiple Parameters in Python
+
+Now that you have defined the function `multiple_values()`, you can call it by providing values for the two input parameters.  
+
+```python
+# Call function with numeric values
+multiply_values(x = 0.7, y = 25.4)
+```
+
+Recall that you can also provide pre-defined variables as inputs, for example, a value for precipitation and another value for a unit conversion value.  
+
+```python
+# Average monthly precip (inches) for Jan in Boulder, CO
+precip_jan_in = 0.7
+
+# Conversion factor from inches to millimeters
+to_mm = 25.4
+```
+
+```python
+# Call function with pre-defined variables
+precip_jan_mm = multiply_values(
+    x = precip_jan_in, 
+    y = to_mm)
+
+precip_jan_mm
+```
+
+Note that the function is not defined specifically for unit conversions, but as it completes a generalizable task, it can be used for simple unit conversions. 
+
+<!-- #region -->
+## Combine Unit Conversion and Calculation of Statistics into One Function
+
+Now imagine that you want to both convert the units of a **numpy** array from millimeters to inches and calculate the mean value along a specified axis for either columns or rows.
+
+Recall the function definition that you previously wrote to convert values from millimeters to inches:
+
+```python
+def mm_to_in(mm):
+    """Convert input from millimeters to inches. 
+    
+    Parameters
+    ----------
+    mm : int or float
+        Numeric value with units in millimeters.
+
+    Returns
+    ------
+    inches : int or float
+        Numeric value with units in inches.
+    """
+    inches = mm / 25.4    
+    return inches
+```
+
+You can expand this function to include running a mean along a specified axis for columns or rows, and then use this function over and over on many **numpy** arrays as needed.  
+
+This new function can have descriptive names for the function and the input parameters that describe more clearly what the function accomplishes. 
+
+Begin by defining the function with a descriptive name and the two necessary parameters: 
+* the input array with values in millimeters
+* the axis value for the mean calculation 
+
+Use placeholder variable names that highlight the purpose of each parameter:
+
+
+```python
+def mean_mm_to_in_arr(arr_mm, axis_value):
+```
+
+
+Next, add the code to first calculate the mean of the input array along a specified axis, and then to convert the mean values from millimeters to inches. 
+
+First, add the code line to calculate a mean along a specified axis. 
+
+
+```python
+def mean_mm_to_in_arr(arr_mm, axis_value):
+    mean_arr_mm = np.mean(arr_mm, axis = axis_value)    
+```
+
+
+Next, add the code line to convert the mean array from millimeters to inches. In this case, the `return` statement should return the mean array in inches.
+
+
+```python
+def mean_mm_to_in_arr(arr_mm, axis_value):
+    mean_arr_mm = np.mean(arr_mm, axis = axis_value)
+    mean_arr_in = mean_arr_mm / 25.4 
+        
+    return mean_arr_in
+    
+```
+
+Note that the function could be written to convert the values first and then calculate the mean. However, given that the function will complete both tasks and return the mean values in the desired units, it is more efficient to calculate the mean values first and then convert just those values, rather than converting all of the values in the input array. 
+
+
+Last, include a docstring to provide the details about this function, including a brief description of the function (i.e. how it works, purpose) as well as identify the input parameters (i.e. type, description) and the returned output (i.e. type, description).
+<!-- #endregion -->
+
+```python
+def mean_mm_to_in_arr(arr_mm, axis_value):
+    """Calculate mean values of input array along a specified
+    axis and convert values from millimeters to inches.
+    
+    Parameters
+    ----------
+    arr_mm : numpy array
+        Numeric values in millimeters.
+    axis_value : int
+        0 to calculate mean for each column.
+        1 to calculate mean for each row.
+
+    Returns
+    ------
+    mean_arr_in : numpy array
+        Mean values of input array in inches.
+    """    
+    mean_arr_mm = np.mean(arr_mm, axis = axis_value)
+    mean_arr_in = mean_arr_mm / 25.4 
+        
+    return mean_arr_in
+```
+
+Now that you have defined `mean_mm_to_in_arr()`, you can call the function with the appropriate input parameters.
+
+Create some data and test your new function with different input values for the `axis_value` parameter.
+
+```python
+# Import necessary package to run function
+import numpy as np
+```
+
+```python
+# 2d array of average monthly precip (mm) for 2002 and 2013 in Boulder, CO
+precip_2002_2013_mm = np.array([[27.178, 11.176, 38.1, 5.08, 81.28, 29.972, 
+                                 2.286, 36.576, 38.608, 61.976, 19.812, 0.508],
+                                [6.858, 28.702, 43.688, 105.156, 67.564, 15.494,  
+                                 26.162, 35.56 , 461.264, 56.896, 7.366, 12.7]
+                               ])
+```
+
+```python
+# Calculate monthly mean (inches) for precip_2002_2013
+monthly_mean_in = mean_mm_to_in_arr(arr_mm = precip_2002_2013_mm, 
+                                    axis_value = 0)
+
+monthly_mean_in
+```
+
+```python
+# Calculate yearly mean (inches) for precip_2002_2013
+yearly_mean_in = mean_mm_to_in_arr(arr_mm = precip_2002_2013_mm, 
+                                   axis_value = 1)
+
+yearly_mean_in
+```
+
+## Define Optional Input Parameters for a Function 
+
+Your previously defined function works well if you want to use a specified axis for the mean.
+
+However, notice what happens when you try to call the function without providing an axis value, such as for a one-dimensional array.
+
+```python
+# 1d array of average monthly precip (mm) for 2002 in Boulder, CO
+precip_2002_mm = np.array([27.178, 11.176, 38.1,  5.08, 81.28, 29.972,  
+                           2.286, 36.576, 38.608, 61.976, 19.812, 0.508])
+```
+
+<!-- #region -->
+```python
+# Calculate mean (inches) for precip_2002
+monthly_mean_in = mean_mm_to_in_arr(arr_mm = precip_2002_mm)
+```
+
+You get an error that the `axis_value` is missing:
+
+```python
+TypeError: mean_mm_to_in_arr() missing 1 required positional argument: 'axis_value'
+```
+<!-- #endregion -->
+
+<!-- #region -->
+What if you want to make the function more generalizable, so that the axis value is optional?
+
+You can do that by specifying a default value for `axis_value` as `None` as shown below:
+
+```python
+def mean_mm_to_in_arr(arr_mm, axis_value=None):
+```
+
+The function will assume that the axis value is `None` (i.e. that an input value has not been provided by the user), unless specified otherwise in the function call.
+
+However, as written, the original function code uses the axis value to calculate the mean, so you need to make a few more changes, so that the mean code runs with an axis value if a value is provided or runs without an axis value if one is not provided.
+
+Luckily, you have already learned about conditional statements, which you can now add to your function to run the mean code with or without an axis value as needed. 
+
+Using a conditional statement, you can check if `axis_value` is equal to `None`, in which case the mean code will run without an axis value. 
+
+```python
+def mean_mm_to_in_arr(arr_mm, axis_value=None):
+    
+    if axis_value is None:
+        mean_arr_mm = np.mean(arr_mm) 
+```
+
+The `else` statement would mean that `axis_value` is not equal to `None` (i.e. a user has provided an input value) and thus would run the mean code with the specified axis value.
+
+```python
+def mean_mm_to_in_arr(arr_mm, axis_value=None):
+    
+    if axis_value is None:
+        mean_arr_mm = np.mean(arr_mm)        
+    else:
+        mean_arr_mm = np.mean(arr_mm, axis = axis_value)
+```
+
+The code for the unit conversion and the `return` remain the same, just with updated names:
+
+```python
+def mean_mm_to_in_arr(arr_mm, axis_value=None):
+    if axis_value is None:
+        mean_arr_mm = np.mean(arr_mm)        
+    else:
+        mean_arr_mm = np.mean(arr_mm, axis = axis_value)
+    
+    mean_arr_in = mean_arr_mm / 25.4 
+        
+    return mean_arr_in
+```
+
+Last, include a docstring to provide the details about this revised function. Notice that the axis value has been labeled optional in the docstring. 
+<!-- #endregion -->
+
+```python
+def mean_mm_to_in_arr(arr_mm, axis_value=None):
+    """Calculate mean values of input array and convert values 
+    from millimeters to inches. If an axis is specified,
+    the mean will be calculated along that axis. 
+
+    
+    Parameters
+    ----------
+    arr_mm : numpy array
+        Numeric values in millimeters.
+    axis_value : int (optional)
+        0 to calculate mean for each column.
+        1 to calculate mean for each row.
+
+    Returns
+    ------
+    mean_arr_in : numpy array
+        Mean values of input array in inches.
+    """   
+    if axis_value is None:
+        mean_arr_mm = np.mean(arr_mm)        
+    else:
+        mean_arr_mm = np.mean(arr_mm, axis = axis_value)
+    
+    mean_arr_in = mean_arr_mm / 25.4 
+        
+    return mean_arr_in
+```
+
+Notice that the function will return the same output as before for the two-dimensional array `precip_2002_2013_mm`.
+
+```python
+# Calculate monthly mean (inches) for precip_2002_2013
+monthly_mean_in = mean_mm_to_in_arr(arr_mm = precip_2002_2013_mm, 
+                                    axis_value = 0)
+
+monthly_mean_in
+```
+
+However, now you can also provide a one-dimensional array as an input without a specified axis and receive the appropriate output.
+
+```python
+# Calculate mean (inches) for precip_2002
+monthly_mean_in = mean_mm_to_in_arr(arr_mm = precip_2002_mm)
+
+monthly_mean_in
+```
+
+<!-- #region -->
+## Combine Download and Import of Data Files into One Function
+
+You can also write multi-parameter functions to combine other tasks into one function, such as downloading and importing data files into a **pandas** dataframe.
+
+Think about the code that you need to include in the function:
+1. download data file from URL: `et.data.get_data(url=file_url)`
+2. import data file into **pandas** dataframe: `pd.read_csv(path)`
+
+From this code, you can see that you will need two input parameters for the combined function:
+1. the URL to the data file
+2. the path to the downloaded file
+
+Begin by specifying a function name and the placeholder variable names for the necessary input parameters. 
+
+```python
+def download_import_df(file_url, path):  
+```
+
+Next, add the code for download and the import. 
+
+```python
+def download_import_df(file_url, path):  
+    et.data.get_data(url=file_url)  
+    df = pd.read_csv(path)
+```
+
+However, what if the working directory has not been set before this function is called, and you do not want to use absolute paths? 
+
+Since you know that the `get_data()` function creates the `earth-analytics` directory under the home directory if it does not already exist, you can safely assume that this combined function will also create that directory.
+
+As such, you can include setting the working directory in the function, so that you do not have to worry about providing absolute paths to the function:
+
+```python
+def download_import_df(file_url, path):    
+    
+    et.data.get_data(url=file_url)      
+    os.chdir(os.path.join(et.io.HOME, "earth-analytics"))    
+    df = pd.read_csv(path)
+    
+    return df
+```
+
+Last, include a docstring to provide the details about this function, including a brief description of the function (i.e. how it works, purpose) as well as identify the input parameters (i.e. type, description) and the returned output (i.e. type, description).
+<!-- #endregion -->
+
+```python
+def download_import_df(file_url, path):   
+    """Download file from specified URL and import file
+    into a pandas dataframe from a specified path. 
+    
+    Working directory is set to earth-analytics directory 
+    under home, which is automatically created by the
+    download. 
+
+    
+    Parameters
+    ----------
+    file_url : str
+        URL to CSV file (http or https).
+    path : str
+        Path to CSV file using relative path
+        to earth-analytics directory under home.        
+
+    Returns
+    ------
+    df : pandas dataframe
+        Dataframe imported from downloaded CSV file.
+    """ 
+    
+    et.data.get_data(url=file_url)      
+    os.chdir(os.path.join(et.io.HOME, "earth-analytics"))    
+    df = pd.read_csv(path)
+    
+    return df
+```
+
+Now that you have defined the function, you can import the packages needed to run the function and define the variables that you will use as input parameters.
+
+```python
+# Import necessary packages to run function
+import os
+import pandas as pd
+import earthpy as et
+```
+
+```python
+# URL for average monthly precip (inches) for 2002 and 2013 in Boulder, CO
+precip_2002_2013_df_url = "https://ndownloader.figshare.com/files/12710621"
+
+# Path to downloaded .csv file with headers
+precip_2002_2013_df_path = os.path.join("data", "earthpy-downloads", 
+                                        "precip-2002-2013-months-seasons.csv")
+```
+
+Using these variables, you can now call the function to download and import the file into a **pandas** dataframe. 
+
+```python
+# Create dataframe using download/import function
+precip_2002_2013_df = download_import_df(
+    file_url = precip_2002_2013_df_url, 
+    path = precip_2002_2013_df_path)
+
+precip_2002_2013_df
+```
+
+<!-- #region -->
+###  Making Functions More Efficient Does Not Always Mean More Parameters
+
+Note that you previously defined `download_import_df()` to take in two parameters, one for the URL and for the path, and the function works well to accomplish the task.
+
+However, with a little investigation into the `et.data.get_data()` function, you can see that the output of that function is actually a path to the downloaded file!
+
+```python
+help(et.data.get_data)
+```
+In the docstring details provided, you can see that the full path to the downloaded data is returned by the function:
+
+```
+Returns
+-------
+path_data : str
+    The path to the downloaded data.
+```
+
+This means that you can redefine `download_import_df()` to be more efficient by simply using the output of the `et.data.get_data()` function as the input to the `pd.read_csv()` function. 
+
+Now, you actually only need one parameter for the URL and you do not have to define the working directory in the function, in order to find the appropriate file.
+<!-- #endregion -->
+
+```python
+def download_import_df(file_url):   
+    """Download file from specified URL and import file
+    into a pandas dataframe. 
+    
+    The path to the downloaded file is automatically 
+    generated by the download and is passed to the 
+    pandas function to create a new dataframe. 
+    
+    Parameters
+    ----------
+    file_url : str
+        URL to CSV file (http or https).       
+
+    Returns
+    ------
+    df : pandas dataframe
+        Dataframe imported from downloaded CSV file.
+    """ 
+
+    df = pd.read_csv(et.data.get_data(url=file_url))
+    
+    return df
+```
+
+Your revised function now executes only one line, rather than three lines! Note that the docstring was also updated to reflect that there is only one input parameter for this function. 
+
+Now you can call the function with just a single parameter for the URL. 
+
+```python
+# Create dataframe using download/import function
+precip_2002_2013_df = download_import_df(
+    file_url = precip_2002_2013_df_url)
+
+precip_2002_2013_df
+```
+
+<!-- #region -->
+<div class="notice--warning" markdown="1">
+
+## <i class="fa fa-pencil-square-o" aria-hidden="true"></i> Practice Writing Multi-Parameter Functions for Pandas Dataframes
+
+You have a function that combines the mean calculation along a specified axis and the conversion from millimeters to inches for a **numpy** array. 
+
+How might you need to change this function to create a similar function for **pandas** dataframe, but now converting from inches to millimeters?
+
+For the mean, you can run summary statistics on pandas using a specified axis (just like a **numpy** array) with the following code:
+
+```python
+df.mean(axis = axis_value) 
+```
+
+With the axis value `0`, the code will calculate a mean for each numeric column in the dataframe.
+
+With the axis value `1`, the code will calculate a mean for each row with numeric values in the dataframe.
+
+Think about which code lines in the existing function `mean_mm_to_in_arr()` can be modified to run the equivalent code on a **pandas** dataframe.
+
+Note that the `df.mean(axis = axis_value)` returns the mean values of a dataframe (along the specified axis) as a **pandas** series.
+
+</div>
+<!-- #endregion -->
+
+<div class="notice--warning" markdown="1">
+
+## <i class="fa fa-pencil-square-o" aria-hidden="true"></i> Practice Writing Multi-Parameter Functions for Numpy Arrays
+
+You also have a function that combines the data download and import for a **pandas** dataframe, you can modify the function for other data structures such as a **numpy** array. 
+
+How might you need to change this function to create an equivalent for **numpy** arrays?
+
+Think about which code lines in the existing function `download_import_df()` can be modified to write a new function that downloads and imports data into a **numpy** array.
+
+To begin, you may want to write one function for a 1-dimensional array and another function for a 2-dimensional array.
+
+To advance in your practice, you can think about adding a conditional statement that would check for the file type (.txt for a 1-dimensional array .csv for a 2-dimensional array) before executing the appropriate import code. 
+
+</div>

--- a/clean-modular-code/checks-conditionals/write-python-functions.md
+++ b/clean-modular-code/checks-conditionals/write-python-functions.md
@@ -17,6 +17,7 @@ jupyter:
     name: python3
 ---
 
+(write-functions)=
 ## How to write a Python function  
 
 :::{tip}
@@ -54,9 +55,9 @@ add_numbers(1,2)
 ```
 
 <!-- #region -->
-## How to Define Functions in Python
+## How to define functions in Python
 
-There are several components needed to define a function in **Python**, including the `def` keyword, function name, parameters (inputs), and the `return` statement, which specifies the output of the function. 
+Several components are needed to define a function in **Python**, including the `def` keyword, function name, parameters (inputs), and the `return` statement, which specifies the function's output. 
 
 ```python
 def function_name(parameter):
@@ -64,7 +65,7 @@ def function_name(parameter):
     return output
 ```
 
-### def keyword and function Name
+### `def` keyword and function Name
 
 In **Python**, function definitions begin with the keyword **`def`** to indicate the start of a definition for a new function. The function name follows this keyword. 
 

--- a/clean-modular-code/intro-clean-code.md
+++ b/clean-modular-code/intro-clean-code.md
@@ -24,7 +24,7 @@ jupyter:
 
 :::{toctree}
 :hidden:
-:caption: Lessons
+:caption: Clean, Expressive Code
 :maxdepth: 2
 
 Intro <self>
@@ -35,23 +35,16 @@ Expressive Code <python-expressive-code>
 
 :::{toctree}
 :hidden:
-:caption: Functions, Checks & Tests
-:maxdepth: 2
-
-Functions <checks-conditionals/python-functions>
-Functions <checks-conditionals/write-python-functions>
-Function checks <checks-conditionals/python-function-checks>
-Function Tests & Checks <checks-conditionals/tests-checks>
-:::
-
-:::{toctree}
-:hidden:
-:caption: Conditional statements
+:caption: Functions, Conditionals & Checks
 :maxdepth: 2
 
 Conditional statements <checks-conditionals/python-conditionals>
-Tests & Checks <checks-conditionals/python-function-checks>
+Functions <checks-conditionals/about-python-functions>
+Functions <checks-conditionals/write-python-functions>
+Function checks <checks-conditionals/python-function-checks>
+Function Tests & Checks <checks-conditionals/python-common-exceptions>
 :::
+
 
 :::{toctree}
 :hidden:

--- a/clean-modular-code/python-expressive-code.md
+++ b/clean-modular-code/python-expressive-code.md
@@ -28,6 +28,7 @@ authors: ['Leah Wasser', 'Jenny Palomino']
 
 +++ {"editable": true, "slideshow": {"slide_type": ""}}
 
+(python-expressive)=
 # Make Your Code Easier to Read Using Expressive Variable Names in Python
 
 :::{admonition} Learning Objectives


### PR DESCRIPTION
This is the start to revisiting concepts taught in activity 3. it's a followup of merged pr #18 I will bring several comments over from @ucodery 

1. encourage the fail fast approach to checks. 
2. Raise errors with useful messages rather than using print statements. Print statements will allow the program to continue to run vs raising the error properly so this will avoid failing quietly and encourage fast fails. 

We want to make sure that most of the lesson content is in the lesson rather than the activity but we can then link to it in the activity. 

> Two suggestions I have for this lesson:
> encourage attendees to "fail fast"
> only when it is unrecoverable
> this makes the failure happen earlier, wasting less time waiting
> this can make the stack trace more useful, as it points the the code experiencing the error
> 
> clearly describe the error.
> rather than just printing out "exiting now", try to tell the caller why it was a mistake, and what they could maybe do to fix it.
> maybe also explain that exceptions can (most of the time) take a message string, and it doesn't have to be printed also.


also - [this is the example provided around failing fast ](https://github.com/pyOpenSci/lessons/pull/18#issuecomment-2408079777) 

I think this content could be a single workshop or even a day or two of programming on its own, but we will keep it high-level.