### PR TITLE
Improve pythonic naming in function and minor edits

### DIFF
--- a/clean-modular-code/intro-clean-code.md
+++ b/clean-modular-code/intro-clean-code.md
@@ -158,12 +158,12 @@ Pythonic code communicates the programmer's intent clearly, making it easier for
 
 Note that the function below has an easy-to-understand name and clear docstring. Some people will even suggest adding a verb that explains what the function does, such as:
 
-`convert_fahr_kelvin()`
+`convert_fahrenheit_to_kelvin()`
 
 <!-- #endregion -->
 
 ```python editable=true slideshow={"slide_type": ""}
-def fahrenheit_to_kelvin(temperature_fahr):
+def convert_fahrenheit_to_kelvin(temperature_fahr):
     return ((temperature_fahr - 32) * (5 / 9)) + 273.15
 ```
 
@@ -176,7 +176,7 @@ Documentation can mean many different things. When you are writing code, a combi
 Pythonic code reflects Python's emphasis on readability and simplicity. A well-known phrase from the **Zen of Python** is: "There should be one—and preferably only one—obvious way to do it," which is a core idea behind writing Pythonic code.
 
 ```python
-def fahrenheit_to_kelvin(temperature_fahr):
+def convert_fahrenheit_to_kelvin(temperature_fahr):
     """
     Convert temperature from Fahrenheit to Kelvin.
 

--- a/clean-modular-code/intro-clean-code.md
+++ b/clean-modular-code/intro-clean-code.md
@@ -91,6 +91,7 @@ import this
 ```python editable=true slideshow={"slide_type": ""}
 # Not Pythonic
 import datetime
+
 foovar = datetime.date.today().strftime("%y-%m-%d")
 foovar
 ```
@@ -98,6 +99,7 @@ foovar
 ```python editable=true slideshow={"slide_type": ""}
 # Pythonic
 import datetime
+
 todays_date = datetime.date.today().strftime("%y-%m-%d")
 todays_date
 ```
@@ -124,6 +126,8 @@ result
 result = [i * 2 for i in range(10)]
 result
 ```
+
+Another example:
 
 ```python
 # More Pythonic
@@ -157,8 +161,8 @@ Note that the function below has an easy-to-understand name and clear docstring.
 <!-- #endregion -->
 
 ```python editable=true slideshow={"slide_type": ""}
-def fahr_to_kelvin(fahr):
-    return ((fahr - 32) * (5 / 9)) + 273.15
+def fahrenheit_to_kelvin(temperature_fahr):
+    return ((temperature_fahr - 32) * (5 / 9)) + 273.15
 ```
 
 ### Pythonic code is well-documented
@@ -170,13 +174,13 @@ Documentation can mean many different things. When you are writing code, a combi
 Pythonic code reflects Python's emphasis on readability and simplicity. A well-known phrase from the **Zen of Python** is: "There should be one—and preferably only one—obvious way to do it," which is a core idea behind writing Pythonic code.
 
 ```python
-def fahr_to_kelvin(fahr):
+def fahrenheit_to_kelvin(temperature_fahr):
     """
     Convert temperature from Fahrenheit to Kelvin.
 
     Parameters
     ----------
-    fahr : float
+    temperature_fahr : float
         Temperature in Fahrenheit.
 
     Returns
@@ -184,7 +188,7 @@ def fahr_to_kelvin(fahr):
     float
         Temperature in Kelvin.
     """
-    return ((fahr - 32) * (5 / 9)) + 273.15
+    return ((temperature_fahr - 32) * (5 / 9)) + 273.15
 ```
 
 <!-- #region editable=true slideshow={"slide_type": ""} -->

--- a/clean-modular-code/intro-clean-code.md
+++ b/clean-modular-code/intro-clean-code.md
@@ -132,6 +132,7 @@ Another example:
 ```python
 # More Pythonic
 languages = ["python", "julia", "rust"]
+
 i=0
 for language in(languages):
     i+=1
@@ -140,9 +141,10 @@ for language in(languages):
 
 ```python
 # More Pythonic
-a = ["python", "julia", "rust"]
-for i, language in enumerate(languages):
-    print(f"{i}: {language}")
+languages = ["python", "julia", "rust"]
+
+for index, language in enumerate(languages):
+    print(f"{index}: {language}")
 ```
 
 <!-- #region editable=true slideshow={"slide_type": ""} -->


### PR DESCRIPTION
This PR updates the "Intro to clean code lesson":
- adds newline after imports in examples
- add a logical separation ("Another example") between two sets of examples
- make the names for temperature example more explicit
- correct code example