### PR TITLE
[css] reduce spacing around admonitions

### DIFF
--- a/_static/css/styles.css
+++ b/_static/css/styles.css
@@ -1,3 +1,8 @@
+div.admonition {
+	margin-top: 1em !important;
+	margin-bottom: 1.5em !important;
+}
+
 
 .navbar-header-items .navbar-header-items__center {
 	margin-left: 2em !important;


### PR DESCRIPTION
It looks like my reduction of the spacing around admonitions got removed here? https://github.com/pyOpenSci/lessons/commit/75e89a8729f3e7821d92025c30afec25075ce0ed

Not sure if this was on purpose or not, i know there has been a lot of rapid change in this repo lately :). I think Leah and I in general have different tastes in layout, which is totally fine, so i'm just checking, close this if it was on purpose.

Currently the margins are fixed size (60px/70px), which to my eyes is a lot. The admonitions are already visually offset being in boxes, and the other dom elements like sections and headers also already have their own margins, and so with this amount of spacing they (imo) disrupt the flow of text enough to warrant change. I think it's especially obvious on mobile:

| between headings | in text |
| --- | --- |
|  <img width="396" alt="Screenshot 2024-10-23 at 5 16 02 PM" src="https://github.com/user-attachments/assets/407e7cd9-5bd2-4976-9ac2-ac4b3d24fa98"> | <img width="413" alt="Screenshot 2024-10-23 at 5 17 10 PM" src="https://github.com/user-attachments/assets/c385b971-f305-49c2-a0b1-d53718e0de04">|

So this PR does:

| between headings | in text |
| --- | --- |
| <img width="410" alt="Screenshot 2024-10-23 at 5 23 09 PM" src="https://github.com/user-attachments/assets/63d96115-1adf-4ba2-8a5e-d7bf48a70c24"> | <img width="409" alt="Screenshot 2024-10-23 at 5 22 47 PM" src="https://github.com/user-attachments/assets/c03944a2-a8fc-4187-ad04-f860e2f9844a"> |

