### PR TITLE
Add admonition for github actions in forks

### DIFF
--- a/contribute-open-source/fork-repo.md
+++ b/contribute-open-source/fork-repo.md
@@ -108,6 +108,21 @@ Your fork **is a separate copy**, but it remains linked to the original reposito
 > - Keep your fork updated as the original repo evolves.
 > - Submit changes back using a **pull request**.
 
+:::{admonition} GitHub Actions Testing
+
+If the source repository has existing Actions, they are turned off in the 
+forked copy for security reasons.
+
+- It is important to understand all implications of Actions tests before running them in your own fork
+- Tests run in Actions often require repository secrets to execute, these are not available to forks
+
+Repositories create tests that run based on triggers, such as pull requests, merges, and
+even on a regular schedule. These may not be appropriate to run in your fork. However, there are cases where running functional tests locally may be beneficial in order to pre-validate changes that you are staging for a future pull request. 
+
+Most repositories write these tests and include them in their repository tree, which will be included in your fork. When you submit a pull request, the same tests will execute from the main repository. You should consult documentation available on the source repository for the recommended method to run their tests. 
+:::
+
+
 ::::{todo}
  /images/github/fork-structure.png
 :alt: "Diagram showing how forking creates a personal copy linked to the original."

--- a/contribute-open-source/index.md
+++ b/contribute-open-source/index.md
@@ -127,14 +127,13 @@ GitHub is widely used in **open source** and **team-based projects** where multi
 Now that you understand GitHub's role in **open source** and **collaboration**,
 you're ready to dive into **contributing to a project!**
 
-*****
 
 * <i class="fa-brands fa-github-alt"></i> [Get started with activities to guide you through your first contribution →](pyos-first-contribution)
 * <i class="fa-brands fa-github-alt"></i> [Learn how to identify an issue →](identify-github-issue)
 * <i class="fa-brands fa-github-alt"></i> [Learn how to fork a repository →](fork-repository)
 :::
 
-*********
+
 
 *This work was supported by the Better Scientific Software Fellowship Program, a collaborative effort of the U.S. Department of Energy (DOE), Office of Advanced Scientific Research via ANL under Contract DE-AC02-06CH11357 and the National Nuclear Security Administration Advanced Simulation and Computing Program via LLNL under Contract DE-AC52-07NA27344; and by the National Science Foundation (NSF) via SHI under Grant No. 2327079.*
 

--- a/contribute-open-source/your-first-contribution.md
+++ b/contribute-open-source/your-first-contribution.md
@@ -117,7 +117,7 @@ Once you have created an issue or identified what you wish to work on, you will 
 :::{admonition} Activity: Fork a repository and modify a file
 
 **Fork the pyOpenSci practice GitHub repository**
-*******
+
 
 * Navigate to the [pyOpenSci example repo](https://github.com/pyOpenSci/pyos-demo-package-contribute).
 * Fork the repository.
@@ -125,7 +125,7 @@ Once you have created an issue or identified what you wish to work on, you will 
 *Remember that a fork is a copy of a repository that is owned by someone else or an organization that lives in your GitHub account.*
 :::
 
-********
+******
 
 ### Step 4: Edit and commit your changes
 

--- a/write-better-code/clean-modular-code/activity-3/clean-code-activity-3.md
+++ b/write-better-code/clean-modular-code/activity-3/clean-code-activity-3.md
@@ -715,7 +715,7 @@ def format_date(date_parts: list) -> str:
     Returns
     -------
     pd.datetime
-        A date formatted as a `pd.datetime` object.
+        A date formatted as a pd.datetime object.
     """
     date_str = f"{date_parts[0][0]}-{date_parts[0][1]:02d}-{date_parts[0][2]:02d}"
     return pd.to_datetime(date_str, format="%Y-%m-%d")
@@ -732,7 +732,7 @@ def clean_title(value):
     Returns
     -------
     Any
-        The first element of the list `value`.
+        The first element of the list value.
     """
     print("hi", value)
     return value[0]


### PR DESCRIPTION
Suggested text was added to the section on forking repositories in order to provide some basic explanation about why GitHub Actions are deactivated on forks.

closes #114 